### PR TITLE
Fix: Correct 'EaEaLeft' naming error in celebratestyle.css

### DIFF
--- a/wwwroot/css/CelebrateStyle.css
+++ b/wwwroot/css/CelebrateStyle.css
@@ -116402,813 +116402,813 @@ Extra Extra Large = EaEaLe = ≥1400px
         bottom: 100%;
     }
 
-    /* EaEaLeft => 0 to 100 {px} */
+    /* left => 0 to 100 {px} */
     .EaEaLe\:PnLt0 {
-        EaEaLeft: var(--Pl0);
+        left: var(--Pl0);
     }
 
     .EaEaLe\:PnLt1 {
-        EaEaLeft: var(--Pl1);
+        left: var(--Pl1);
     }
 
     .EaEaLe\:PnLt2 {
-        EaEaLeft: var(--Pl2);
+        left: var(--Pl2);
     }
 
     .EaEaLe\:PnLt3 {
-        EaEaLeft: var(--Pl3);
+        left: var(--Pl3);
     }
 
     .EaEaLe\:PnLt4 {
-        EaEaLeft: var(--Pl4);
+        left: var(--Pl4);
     }
 
     .EaEaLe\:PnLt5 {
-        EaEaLeft: var(--Pl5);
+        left: var(--Pl5);
     }
 
     .EaEaLe\:PnLt6 {
-        EaEaLeft: var(--Pl6);
+        left: var(--Pl6);
     }
 
     .EaEaLe\:PnLt7 {
-        EaEaLeft: var(--Pl7);
+        left: var(--Pl7);
     }
 
     .EaEaLe\:PnLt8 {
-        EaEaLeft: var(--Pl8);
+        left: var(--Pl8);
     }
 
     .EaEaLe\:PnLt9 {
-        EaEaLeft: var(--Pl9);
+        left: var(--Pl9);
     }
 
     .EaEaLe\:PnLt10 {
-        EaEaLeft: var(--Pl10);
+        left: var(--Pl10);
     }
 
     .EaEaLe\:PnLt11 {
-        EaEaLeft: var(--Pl11);
+        left: var(--Pl11);
     }
 
     .EaEaLe\:PnLt12 {
-        EaEaLeft: var(--Pl12);
+        left: var(--Pl12);
     }
 
     .EaEaLe\:PnLt13 {
-        EaEaLeft: var(--Pl13);
+        left: var(--Pl13);
     }
 
     .EaEaLe\:PnLt14 {
-        EaEaLeft: var(--Pl14);
+        left: var(--Pl14);
     }
 
     .EaEaLe\:PnLt15 {
-        EaEaLeft: var(--Pl15);
+        left: var(--Pl15);
     }
 
     .EaEaLe\:PnLt16 {
-        EaEaLeft: var(--Pl16);
+        left: var(--Pl16);
     }
 
     .EaEaLe\:PnLt17 {
-        EaEaLeft: var(--Pl17);
+        left: var(--Pl17);
     }
 
     .EaEaLe\:PnLt18 {
-        EaEaLeft: var(--Pl18);
+        left: var(--Pl18);
     }
 
     .EaEaLe\:PnLt19 {
-        EaEaLeft: var(--Pl19);
+        left: var(--Pl19);
     }
 
     .EaEaLe\:PnLt20 {
-        EaEaLeft: var(--Pl20);
+        left: var(--Pl20);
     }
 
     .EaEaLe\:PnLt21 {
-        EaEaLeft: var(--Pl21);
+        left: var(--Pl21);
     }
 
     .EaEaLe\:PnLt22 {
-        EaEaLeft: var(--Pl22);
+        left: var(--Pl22);
     }
 
     .EaEaLe\:PnLt23 {
-        EaEaLeft: var(--Pl23);
+        left: var(--Pl23);
     }
 
     .EaEaLe\:PnLt24 {
-        EaEaLeft: var(--Pl24);
+        left: var(--Pl24);
     }
 
     .EaEaLe\:PnLt25 {
-        EaEaLeft: var(--Pl25);
+        left: var(--Pl25);
     }
 
     .EaEaLe\:PnLt26 {
-        EaEaLeft: var(--Pl26);
+        left: var(--Pl26);
     }
 
     .EaEaLe\:PnLt27 {
-        EaEaLeft: var(--Pl27);
+        left: var(--Pl27);
     }
 
     .EaEaLe\:PnLt28 {
-        EaEaLeft: var(--Pl28);
+        left: var(--Pl28);
     }
 
     .EaEaLe\:PnLt29 {
-        EaEaLeft: var(--Pl29);
+        left: var(--Pl29);
     }
 
     .EaEaLe\:PnLt30 {
-        EaEaLeft: var(--Pl30);
+        left: var(--Pl30);
     }
 
     .EaEaLe\:PnLt31 {
-        EaEaLeft: var(--Pl31);
+        left: var(--Pl31);
     }
 
     .EaEaLe\:PnLt32 {
-        EaEaLeft: var(--Pl32);
+        left: var(--Pl32);
     }
 
     .EaEaLe\:PnLt33 {
-        EaEaLeft: var(--Pl33);
+        left: var(--Pl33);
     }
 
     .EaEaLe\:PnLt34 {
-        EaEaLeft: var(--Pl34);
+        left: var(--Pl34);
     }
 
     .EaEaLe\:PnLt35 {
-        EaEaLeft: var(--Pl35);
+        left: var(--Pl35);
     }
 
     .EaEaLe\:PnLt36 {
-        EaEaLeft: var(--Pl36);
+        left: var(--Pl36);
     }
 
     .EaEaLe\:PnLt37 {
-        EaEaLeft: var(--Pl37);
+        left: var(--Pl37);
     }
 
     .EaEaLe\:PnLt38 {
-        EaEaLeft: var(--Pl38);
+        left: var(--Pl38);
     }
 
     .EaEaLe\:PnLt39 {
-        EaEaLeft: var(--Pl39);
+        left: var(--Pl39);
     }
 
     .EaEaLe\:PnLt40 {
-        EaEaLeft: var(--Pl40);
+        left: var(--Pl40);
     }
 
     .EaEaLe\:PnLt41 {
-        EaEaLeft: var(--Pl41);
+        left: var(--Pl41);
     }
 
     .EaEaLe\:PnLt42 {
-        EaEaLeft: var(--Pl42);
+        left: var(--Pl42);
     }
 
     .EaEaLe\:PnLt43 {
-        EaEaLeft: var(--Pl43);
+        left: var(--Pl43);
     }
 
     .EaEaLe\:PnLt44 {
-        EaEaLeft: var(--Pl44);
+        left: var(--Pl44);
     }
 
     .EaEaLe\:PnLt45 {
-        EaEaLeft: var(--Pl45);
+        left: var(--Pl45);
     }
 
     .EaEaLe\:PnLt46 {
-        EaEaLeft: var(--Pl46);
+        left: var(--Pl46);
     }
 
     .EaEaLe\:PnLt47 {
-        EaEaLeft: var(--Pl47);
+        left: var(--Pl47);
     }
 
     .EaEaLe\:PnLt48 {
-        EaEaLeft: var(--Pl48);
+        left: var(--Pl48);
     }
 
     .EaEaLe\:PnLt49 {
-        EaEaLeft: var(--Pl49);
+        left: var(--Pl49);
     }
 
     .EaEaLe\:PnLt50 {
-        EaEaLeft: var(--Pl50);
+        left: var(--Pl50);
     }
 
     .EaEaLe\:PnLt51 {
-        EaEaLeft: var(--Pl51);
+        left: var(--Pl51);
     }
 
     .EaEaLe\:PnLt52 {
-        EaEaLeft: var(--Pl52);
+        left: var(--Pl52);
     }
 
     .EaEaLe\:PnLt53 {
-        EaEaLeft: var(--Pl53);
+        left: var(--Pl53);
     }
 
     .EaEaLe\:PnLt54 {
-        EaEaLeft: var(--Pl54);
+        left: var(--Pl54);
     }
 
     .EaEaLe\:PnLt55 {
-        EaEaLeft: var(--Pl55);
+        left: var(--Pl55);
     }
 
     .EaEaLe\:PnLt56 {
-        EaEaLeft: var(--Pl56);
+        left: var(--Pl56);
     }
 
     .EaEaLe\:PnLt57 {
-        EaEaLeft: var(--Pl57);
+        left: var(--Pl57);
     }
 
     .EaEaLe\:PnLt58 {
-        EaEaLeft: var(--Pl58);
+        left: var(--Pl58);
     }
 
     .EaEaLe\:PnLt59 {
-        EaEaLeft: var(--Pl59);
+        left: var(--Pl59);
     }
 
     .EaEaLe\:PnLt60 {
-        EaEaLeft: var(--Pl60);
+        left: var(--Pl60);
     }
 
     .EaEaLe\:PnLt61 {
-        EaEaLeft: var(--Pl61);
+        left: var(--Pl61);
     }
 
     .EaEaLe\:PnLt62 {
-        EaEaLeft: var(--Pl62);
+        left: var(--Pl62);
     }
 
     .EaEaLe\:PnLt63 {
-        EaEaLeft: var(--Pl63);
+        left: var(--Pl63);
     }
 
     .EaEaLe\:PnLt64 {
-        EaEaLeft: var(--Pl64);
+        left: var(--Pl64);
     }
 
     .EaEaLe\:PnLt65 {
-        EaEaLeft: var(--Pl65);
+        left: var(--Pl65);
     }
 
     .EaEaLe\:PnLt66 {
-        EaEaLeft: var(--Pl66);
+        left: var(--Pl66);
     }
 
     .EaEaLe\:PnLt67 {
-        EaEaLeft: var(--Pl67);
+        left: var(--Pl67);
     }
 
     .EaEaLe\:PnLt68 {
-        EaEaLeft: var(--Pl68);
+        left: var(--Pl68);
     }
 
     .EaEaLe\:PnLt69 {
-        EaEaLeft: var(--Pl69);
+        left: var(--Pl69);
     }
 
     .EaEaLe\:PnLt70 {
-        EaEaLeft: var(--Pl70);
+        left: var(--Pl70);
     }
 
     .EaEaLe\:PnLt71 {
-        EaEaLeft: var(--Pl71);
+        left: var(--Pl71);
     }
 
     .EaEaLe\:PnLt72 {
-        EaEaLeft: var(--Pl72);
+        left: var(--Pl72);
     }
 
     .EaEaLe\:PnLt73 {
-        EaEaLeft: var(--Pl73);
+        left: var(--Pl73);
     }
 
     .EaEaLe\:PnLt74 {
-        EaEaLeft: var(--Pl74);
+        left: var(--Pl74);
     }
 
     .EaEaLe\:PnLt75 {
-        EaEaLeft: var(--Pl75);
+        left: var(--Pl75);
     }
 
     .EaEaLe\:PnLt76 {
-        EaEaLeft: var(--Pl76);
+        left: var(--Pl76);
     }
 
     .EaEaLe\:PnLt77 {
-        EaEaLeft: var(--Pl77);
+        left: var(--Pl77);
     }
 
     .EaEaLe\:PnLt78 {
-        EaEaLeft: var(--Pl78);
+        left: var(--Pl78);
     }
 
     .EaEaLe\:PnLt79 {
-        EaEaLeft: var(--Pl79);
+        left: var(--Pl79);
     }
 
     .EaEaLe\:PnLt80 {
-        EaEaLeft: var(--Pl80);
+        left: var(--Pl80);
     }
 
     .EaEaLe\:PnLt81 {
-        EaEaLeft: var(--Pl81);
+        left: var(--Pl81);
     }
 
     .EaEaLe\:PnLt82 {
-        EaEaLeft: var(--Pl82);
+        left: var(--Pl82);
     }
 
     .EaEaLe\:PnLt83 {
-        EaEaLeft: var(--Pl83);
+        left: var(--Pl83);
     }
 
     .EaEaLe\:PnLt84 {
-        EaEaLeft: var(--Pl84);
+        left: var(--Pl84);
     }
 
     .EaEaLe\:PnLt85 {
-        EaEaLeft: var(--Pl85);
+        left: var(--Pl85);
     }
 
     .EaEaLe\:PnLt86 {
-        EaEaLeft: var(--Pl86);
+        left: var(--Pl86);
     }
 
     .EaEaLe\:PnLt87 {
-        EaEaLeft: var(--Pl87);
+        left: var(--Pl87);
     }
 
     .EaEaLe\:PnLt88 {
-        EaEaLeft: var(--Pl88);
+        left: var(--Pl88);
     }
 
     .EaEaLe\:PnLt89 {
-        EaEaLeft: var(--Pl89);
+        left: var(--Pl89);
     }
 
     .EaEaLe\:PnLt90 {
-        EaEaLeft: var(--Pl90);
+        left: var(--Pl90);
     }
 
     .EaEaLe\:PnLt91 {
-        EaEaLeft: var(--Pl91);
+        left: var(--Pl91);
     }
 
     .EaEaLe\:PnLt92 {
-        EaEaLeft: var(--Pl92);
+        left: var(--Pl92);
     }
 
     .EaEaLe\:PnLt93 {
-        EaEaLeft: var(--Pl93);
+        left: var(--Pl93);
     }
 
     .EaEaLe\:PnLt94 {
-        EaEaLeft: var(--Pl94);
+        left: var(--Pl94);
     }
 
     .EaEaLe\:PnLt95 {
-        EaEaLeft: var(--Pl95);
+        left: var(--Pl95);
     }
 
     .EaEaLe\:PnLt96 {
-        EaEaLeft: var(--Pl96);
+        left: var(--Pl96);
     }
 
     .EaEaLe\:PnLt97 {
-        EaEaLeft: var(--Pl97);
+        left: var(--Pl97);
     }
 
     .EaEaLe\:PnLt98 {
-        EaEaLeft: var(--Pl98);
+        left: var(--Pl98);
     }
 
     .EaEaLe\:PnLt99 {
-        EaEaLeft: var(--Pl99);
+        left: var(--Pl99);
     }
 
     .EaEaLe\:PnLt100 {
-        EaEaLeft: var(--Pl100);
+        left: var(--Pl100);
     }
-    /* EaEaLeft => 0 to 100 {%} */
+    /* left => 0 to 100 {%} */
     .EaEaLe\:PnLt0p {
-        EaEaLeft: 0%;
+        left: 0%;
     }
 
     .EaEaLe\:PnLt1p {
-        EaEaLeft: 1%;
+        left: 1%;
     }
 
     .EaEaLe\:PnLt2p {
-        EaEaLeft: 2%;
+        left: 2%;
     }
 
     .EaEaLe\:PnLt3p {
-        EaEaLeft: 3%;
+        left: 3%;
     }
 
     .EaEaLe\:PnLt4p {
-        EaEaLeft: 4%;
+        left: 4%;
     }
 
     .EaEaLe\:PnLt5p {
-        EaEaLeft: 5%;
+        left: 5%;
     }
 
     .EaEaLe\:PnLt6p {
-        EaEaLeft: 6%;
+        left: 6%;
     }
 
     .EaEaLe\:PnLt7p {
-        EaEaLeft: 7%;
+        left: 7%;
     }
 
     .EaEaLe\:PnLt8p {
-        EaEaLeft: 8%;
+        left: 8%;
     }
 
     .EaEaLe\:PnLt9p {
-        EaEaLeft: 9%;
+        left: 9%;
     }
 
     .EaEaLe\:PnLt10p {
-        EaEaLeft: 10%;
+        left: 10%;
     }
 
     .EaEaLe\:PnLt11p {
-        EaEaLeft: 11%;
+        left: 11%;
     }
 
     .EaEaLe\:PnLt12p {
-        EaEaLeft: 12%;
+        left: 12%;
     }
 
     .EaEaLe\:PnLt13p {
-        EaEaLeft: 13%;
+        left: 13%;
     }
 
     .EaEaLe\:PnLt14p {
-        EaEaLeft: 14%;
+        left: 14%;
     }
 
     .EaEaLe\:PnLt15p {
-        EaEaLeft: 15%;
+        left: 15%;
     }
 
     .EaEaLe\:PnLt16p {
-        EaEaLeft: 16%;
+        left: 16%;
     }
 
     .EaEaLe\:PnLt17p {
-        EaEaLeft: 17%;
+        left: 17%;
     }
 
     .EaEaLe\:PnLt18p {
-        EaEaLeft: 18%;
+        left: 18%;
     }
 
     .EaEaLe\:PnLt19p {
-        EaEaLeft: 19%;
+        left: 19%;
     }
 
     .EaEaLe\:PnLt20p {
-        EaEaLeft: 20%;
+        left: 20%;
     }
 
     .EaEaLe\:PnLt21p {
-        EaEaLeft: 21%;
+        left: 21%;
     }
 
     .EaEaLe\:PnLt22p {
-        EaEaLeft: 22%;
+        left: 22%;
     }
 
     .EaEaLe\:PnLt23p {
-        EaEaLeft: 23%;
+        left: 23%;
     }
 
     .EaEaLe\:PnLt24p {
-        EaEaLeft: 24%;
+        left: 24%;
     }
 
     .EaEaLe\:PnLt25p {
-        EaEaLeft: 25%;
+        left: 25%;
     }
 
     .EaEaLe\:PnLt26p {
-        EaEaLeft: 26%;
+        left: 26%;
     }
 
     .EaEaLe\:PnLt27p {
-        EaEaLeft: 27%;
+        left: 27%;
     }
 
     .EaEaLe\:PnLt28p {
-        EaEaLeft: 28%;
+        left: 28%;
     }
 
     .EaEaLe\:PnLt29p {
-        EaEaLeft: 29%;
+        left: 29%;
     }
 
     .EaEaLe\:PnLt30p {
-        EaEaLeft: 30%;
+        left: 30%;
     }
 
     .EaEaLe\:PnLt31p {
-        EaEaLeft: 31%;
+        left: 31%;
     }
 
     .EaEaLe\:PnLt32p {
-        EaEaLeft: 32%;
+        left: 32%;
     }
 
     .EaEaLe\:PnLt33p {
-        EaEaLeft: 33%;
+        left: 33%;
     }
 
     .EaEaLe\:PnLt34p {
-        EaEaLeft: 34%;
+        left: 34%;
     }
 
     .EaEaLe\:PnLt35p {
-        EaEaLeft: 35%;
+        left: 35%;
     }
 
     .EaEaLe\:PnLt36p {
-        EaEaLeft: 36%;
+        left: 36%;
     }
 
     .EaEaLe\:PnLt37p {
-        EaEaLeft: 37%;
+        left: 37%;
     }
 
     .EaEaLe\:PnLt38p {
-        EaEaLeft: 38%;
+        left: 38%;
     }
 
     .EaEaLe\:PnLt39p {
-        EaEaLeft: 39%;
+        left: 39%;
     }
 
     .EaEaLe\:PnLt40p {
-        EaEaLeft: 40%;
+        left: 40%;
     }
 
     .EaEaLe\:PnLt41p {
-        EaEaLeft: 41%;
+        left: 41%;
     }
 
     .EaEaLe\:PnLt42p {
-        EaEaLeft: 42%;
+        left: 42%;
     }
 
     .EaEaLe\:PnLt43p {
-        EaEaLeft: 43%;
+        left: 43%;
     }
 
     .EaEaLe\:PnLt44p {
-        EaEaLeft: 44%;
+        left: 44%;
     }
 
     .EaEaLe\:PnLt45p {
-        EaEaLeft: 45%;
+        left: 45%;
     }
 
     .EaEaLe\:PnLt46p {
-        EaEaLeft: 46%;
+        left: 46%;
     }
 
     .EaEaLe\:PnLt47p {
-        EaEaLeft: 47%;
+        left: 47%;
     }
 
     .EaEaLe\:PnLt48p {
-        EaEaLeft: 48%;
+        left: 48%;
     }
 
     .EaEaLe\:PnLt49p {
-        EaEaLeft: 49%;
+        left: 49%;
     }
 
     .EaEaLe\:PnLt50p {
-        EaEaLeft: 50%;
+        left: 50%;
     }
 
     .EaEaLe\:PnLt51p {
-        EaEaLeft: 51%;
+        left: 51%;
     }
 
     .EaEaLe\:PnLt52p {
-        EaEaLeft: 52%;
+        left: 52%;
     }
 
     .EaEaLe\:PnLt53p {
-        EaEaLeft: 53%;
+        left: 53%;
     }
 
     .EaEaLe\:PnLt54p {
-        EaEaLeft: 54%;
+        left: 54%;
     }
 
     .EaEaLe\:PnLt55p {
-        EaEaLeft: 55%;
+        left: 55%;
     }
 
     .EaEaLe\:PnLt56p {
-        EaEaLeft: 56%;
+        left: 56%;
     }
 
     .EaEaLe\:PnLt57p {
-        EaEaLeft: 57%;
+        left: 57%;
     }
 
     .EaEaLe\:PnLt58p {
-        EaEaLeft: 58%;
+        left: 58%;
     }
 
     .EaEaLe\:PnLt59p {
-        EaEaLeft: 59%;
+        left: 59%;
     }
 
     .EaEaLe\:PnLt60p {
-        EaEaLeft: 60%;
+        left: 60%;
     }
 
     .EaEaLe\:PnLt61p {
-        EaEaLeft: 61%;
+        left: 61%;
     }
 
     .EaEaLe\:PnLt62p {
-        EaEaLeft: 62%;
+        left: 62%;
     }
 
     .EaEaLe\:PnLt63p {
-        EaEaLeft: 63%;
+        left: 63%;
     }
 
     .EaEaLe\:PnLt64p {
-        EaEaLeft: 64%;
+        left: 64%;
     }
 
     .EaEaLe\:PnLt65p {
-        EaEaLeft: 65%;
+        left: 65%;
     }
 
     .EaEaLe\:PnLt66p {
-        EaEaLeft: 66%;
+        left: 66%;
     }
 
     .EaEaLe\:PnLt67p {
-        EaEaLeft: 67%;
+        left: 67%;
     }
 
     .EaEaLe\:PnLt68p {
-        EaEaLeft: 68%;
+        left: 68%;
     }
 
     .EaEaLe\:PnLt69p {
-        EaEaLeft: 69%;
+        left: 69%;
     }
 
     .EaEaLe\:PnLt70p {
-        EaEaLeft: 70%;
+        left: 70%;
     }
 
     .EaEaLe\:PnLt71p {
-        EaEaLeft: 71%;
+        left: 71%;
     }
 
     .EaEaLe\:PnLt72p {
-        EaEaLeft: 72%;
+        left: 72%;
     }
 
     .EaEaLe\:PnLt73p {
-        EaEaLeft: 73%;
+        left: 73%;
     }
 
     .EaEaLe\:PnLt74p {
-        EaEaLeft: 74%;
+        left: 74%;
     }
 
     .EaEaLe\:PnLt75p {
-        EaEaLeft: 75%;
+        left: 75%;
     }
 
     .EaEaLe\:PnLt76p {
-        EaEaLeft: 76%;
+        left: 76%;
     }
 
     .EaEaLe\:PnLt77p {
-        EaEaLeft: 77%;
+        left: 77%;
     }
 
     .EaEaLe\:PnLt78p {
-        EaEaLeft: 78%;
+        left: 78%;
     }
 
     .EaEaLe\:PnLt79p {
-        EaEaLeft: 79%;
+        left: 79%;
     }
 
     .EaEaLe\:PnLt80p {
-        EaEaLeft: 80%;
+        left: 80%;
     }
 
     .EaEaLe\:PnLt81p {
-        EaEaLeft: 81%;
+        left: 81%;
     }
 
     .EaEaLe\:PnLt82p {
-        EaEaLeft: 82%;
+        left: 82%;
     }
 
     .EaEaLe\:PnLt83p {
-        EaEaLeft: 83%;
+        left: 83%;
     }
 
     .EaEaLe\:PnLt84p {
-        EaEaLeft: 84%;
+        left: 84%;
     }
 
     .EaEaLe\:PnLt85p {
-        EaEaLeft: 85%;
+        left: 85%;
     }
 
     .EaEaLe\:PnLt86p {
-        EaEaLeft: 86%;
+        left: 86%;
     }
 
     .EaEaLe\:PnLt87p {
-        EaEaLeft: 87%;
+        left: 87%;
     }
 
     .EaEaLe\:PnLt88p {
-        EaEaLeft: 88%;
+        left: 88%;
     }
 
     .EaEaLe\:PnLt89p {
-        EaEaLeft: 89%;
+        left: 89%;
     }
 
     .EaEaLe\:PnLt90p {
-        EaEaLeft: 90%;
+        left: 90%;
     }
 
     .EaEaLe\:PnLt91p {
-        EaEaLeft: 91%;
+        left: 91%;
     }
 
     .EaEaLe\:PnLt92p {
-        EaEaLeft: 92%;
+        left: 92%;
     }
 
     .EaEaLe\:PnLt93p {
-        EaEaLeft: 93%;
+        left: 93%;
     }
 
     .EaEaLe\:PnLt94p {
-        EaEaLeft: 94%;
+        left: 94%;
     }
 
     .EaEaLe\:PnLt95p {
-        EaEaLeft: 95%;
+        left: 95%;
     }
 
     .EaEaLe\:PnLt96p {
-        EaEaLeft: 96%;
+        left: 96%;
     }
 
     .EaEaLe\:PnLt97p {
-        EaEaLeft: 97%;
+        left: 97%;
     }
 
     .EaEaLe\:PnLt98p {
-        EaEaLeft: 98%;
+        left: 98%;
     }
 
     .EaEaLe\:PnLt99p {
-        EaEaLeft: 99%;
+        left: 99%;
     }
 
     .EaEaLe\:PnLt100p {
-        EaEaLeft: 100%;
+        left: 100%;
     }
 
     /* Right => 0 to 100 {px} */


### PR DESCRIPTION
## Summary
This PR resolves the naming error reported in issue #6 by replacing all instances of the incorrect CSS class name `EaEaLeft` with the correct class name `Left`.

## Changes Made
- Updated `wwwroot/css/celebratestyle.css` to replace `EaEaLeft` with `Left`.
- Verified that styles apply correctly after the rename.
- Ensured there are no references to the old class name in the project.

## Testing Steps
1. Pull the branch `naming-error-eaealeft`.
2. Run the project.
3. Inspect elements previously using `EaEaLeft` and confirm they now use `Left` with correct styling.

## Related Issue
Closes #6

<img width="451" height="320" alt="image" src="https://github.com/user-attachments/assets/a74d980c-19a3-43c3-ab0c-57d98058cd28" />