### PR TITLE
Add utility classes for negative position offsets (-1 to -25) for top, left, bottom, and right

### DIFF
--- a/wwwroot/css/CelebrateStyle.css
+++ b/wwwroot/css/CelebrateStyle.css
@@ -206,9 +206,9 @@ a {
     color: var(--CrTeTt);
 }
 
-a:hover {
-    color: var(--CrTeHrTt);
-}
+    a:hover {
+        color: var(--CrTeHrTt);
+    }
 
 /* *********************** Default Button Style **************************** */
 button, input[type="button"], input[type="submit"], a {
@@ -220,12 +220,30 @@ h1, h2, h3, h4, h5, h6 {
     margin: var(--Pl2);
     font-weight: 600;
 }
-h1 { font-size: var(--Pl32); }
-h2 { font-size: var(--Pl24); }
-h3 { font-size: var(--Pl18); }
-h4 { font-size: var(--Pl16); }
-h5 { font-size: var(--Pl13); }
-h6 { font-size: var(--Pl12); }
+
+h1 {
+    font-size: var(--Pl32);
+}
+
+h2 {
+    font-size: var(--Pl24);
+}
+
+h3 {
+    font-size: var(--Pl18);
+}
+
+h4 {
+    font-size: var(--Pl16);
+}
+
+h5 {
+    font-size: var(--Pl13);
+}
+
+h6 {
+    font-size: var(--Pl12);
+}
 
 /* *********************** LI Tags Style **************************** */
 li {
@@ -260,8 +278,8 @@ li {
     box-shadow: inset 0 0 var(--Pl5) grey;
 }
 
-/* Handle on hover */
-::-webkit-scrollbar-thumb:hover {
+    /* Handle on hover */
+    ::-webkit-scrollbar-thumb:hover {
         background: rgba(132, 205, 185, 0.85);
     }
 
@@ -272,7 +290,7 @@ select {
     font-family: var(--FtFy);
 }
 
-select:focus {
+    select:focus {
         color: var(--CrTeTt);
         background-color: var(--CrTeTtBxBd);
     }
@@ -282,7 +300,7 @@ option {
     background-color: var(--CrTeTtBxBd);
 }
 
-option:hover {
+    option:hover {
         background-color: var(--CrTe);
         color: var(--CrTeHrTt);
     }
@@ -330,10 +348,10 @@ html, body {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='white'%3E%3Cpath d='M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z' stroke='white' stroke-width='2'/%3E%3C/svg%3E");
 }
 
-.CkBx:checked {
-    background-color: var(--checkbox-color);
-    border-color: var(--checkbox-color);
-}
+    .CkBx:checked {
+        background-color: var(--checkbox-color);
+        border-color: var(--checkbox-color);
+    }
 
 /* *********************** Radio Button **************************** */
 .RoBn {
@@ -351,10 +369,10 @@ html, body {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Ccircle cx='12' cy='12' r='6' fill='white'/%3E%3C/svg%3E");
 }
 
-.RoBn:checked {
-    background-color: var(--radio-color);
-    border-color: var(--radio-color);
-}
+    .RoBn:checked {
+        background-color: var(--radio-color);
+        border-color: var(--radio-color);
+    }
 
 /* *********************** Text Box **************************** */
 .TtBx, .TxBxCnAe {
@@ -371,13 +389,14 @@ html, body {
     border-radius: .25rem;
     transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
 }
+
 .TxBxCnAe {
     padding: .65rem .75rem .375rem;
 }
 
-.TtBx:focus, .TxBxCnAe:focus {
-    box-shadow: 0 0px 2px 2px var(--CrTe); /* Thick shadow below */
-}
+    .TtBx:focus, .TxBxCnAe:focus {
+        box-shadow: 0 0px 2px 2px var(--CrTe); /* Thick shadow below */
+    }
 
 .TtBx::placeholder {
     color: #9DA3A8;
@@ -423,9 +442,9 @@ html, body {
     user-select: none;
 }
 
-.SlideFullCloseBn:hover {
-    transform: rotate(360deg) scale(1.05);
-}
+    .SlideFullCloseBn:hover {
+        transform: rotate(360deg) scale(1.05);
+    }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
 .SlideContainer::-webkit-scrollbar {
@@ -442,9 +461,9 @@ html, body {
     overflow-x: scroll
 }
 
-.infiniteScrollSlider::-webkit-scrollbar {
-    display: none
-}
+    .infiniteScrollSlider::-webkit-scrollbar {
+        display: none
+    }
 
 /* *********************** UI Section **************************** */
 .UISn {
@@ -778,31 +797,31 @@ html, body {
     transition: all 0.3s ease-in-out;
 }
 
-.BnEt6:before {
-    content: "";
-    position: absolute;
-    top: calc(50% - 10px);
-    display: none;
-    left: 0;
-    border-right: 10px solid rgba(var(--CrWe));
-    border-top: 10px solid transparent;
-    border-bottom: 10px solid transparent;
-    -webkit-transition: all 0.3s ease-in-out;
-    -o-transition: all 0.3s ease-in-out;
-    transition: all 0.3s ease-in-out;
-}
+    .BnEt6:before {
+        content: "";
+        position: absolute;
+        top: calc(50% - 10px);
+        display: none;
+        left: 0;
+        border-right: 10px solid rgba(var(--CrWe));
+        border-top: 10px solid transparent;
+        border-bottom: 10px solid transparent;
+        -webkit-transition: all 0.3s ease-in-out;
+        -o-transition: all 0.3s ease-in-out;
+        transition: all 0.3s ease-in-out;
+    }
 
-.BnEt6:hover {
-    -webkit-transform: translateX(15px);
-    -ms-transform: translateX(15px);
-    -o-transform: translateX(15px);
-    transform: translateX(15px);
-}
+    .BnEt6:hover {
+        -webkit-transform: translateX(15px);
+        -ms-transform: translateX(15px);
+        -o-transform: translateX(15px);
+        transform: translateX(15px);
+    }
 
-.BnEt6:hover:before {
-    left: -30px;
-    display: flex;
-}
+        .BnEt6:hover:before {
+            left: -30px;
+            display: flex;
+        }
 
 .BnEt7::after {
     content: "+";
@@ -818,41 +837,41 @@ html, body {
     background: none;
 }
 
-.BnEt8::after,
-.BnEt8::before {
-    content: '';
-    display: block;
-    position: absolute;
-    width: 20%;
-    height: 20%;
-    border: 2px solid;
-    transition: all 0.6s ease;
-    border-radius: 2px;
-}
+    .BnEt8::after,
+    .BnEt8::before {
+        content: '';
+        display: block;
+        position: absolute;
+        width: 20%;
+        height: 20%;
+        border: 2px solid;
+        transition: all 0.6s ease;
+        border-radius: 2px;
+    }
 
-.BnEt8::after {
-    bottom: 0;
-    right: 0;
-    border-top-color: transparent;
-    border-left-color: transparent;
-    border-bottom-color: rgba(var(--CrOe));
-    border-right-color: rgba(var(--CrOe));
-}
+    .BnEt8::after {
+        bottom: 0;
+        right: 0;
+        border-top-color: transparent;
+        border-left-color: transparent;
+        border-bottom-color: rgba(var(--CrOe));
+        border-right-color: rgba(var(--CrOe));
+    }
 
-.BnEt8::before {
-    top: 0;
-    left: 0px;
-    border-bottom-color: transparent;
-    border-right-color: transparent;
-    border-top-color: rgba(var(--CrOe));
-    border-left-color: rgba(var(--CrOe));
-}
+    .BnEt8::before {
+        top: 0;
+        left: 0px;
+        border-bottom-color: transparent;
+        border-right-color: transparent;
+        border-top-color: rgba(var(--CrOe));
+        border-left-color: rgba(var(--CrOe));
+    }
 
-.BnEt8:hover:after,
-.BnEt8:hover:before {
-    width: 100%;
-    height: 100%;
-}
+    .BnEt8:hover:after,
+    .BnEt8:hover:before {
+        width: 100%;
+        height: 100%;
+    }
 
 /* *********************** Dropdown **************************** */
 .DpDn {
@@ -954,11 +973,11 @@ html, body {
     white-space: nowrap;
 }
 
-.DpDnLk:hover, .DpDnLk:focus-within {
-    background-color: var(--CrTeStBd);
-    color: var(--CrTeStTt);
-    border-radius: var(--Pl3);
-}
+    .DpDnLk:hover, .DpDnLk:focus-within {
+        background-color: var(--CrTeStBd);
+        color: var(--CrTeStTt);
+        border-radius: var(--Pl3);
+    }
 
 .DpDn .DpDnLk:not(:last-child)::before {
     content: '';
@@ -984,28 +1003,28 @@ html, body {
     z-index: 1;
 }
 
-.dropdownContent a {
-    color: black;
-    padding: 12px 16px;
-    text-decoration: none;
-    display: block;
-}
-
-    .dropdownContent a:hover {
-        background-color: #ddd;
+    .dropdownContent a {
+        color: black;
+        padding: 12px 16px;
+        text-decoration: none;
+        display: block;
     }
 
-/* Default position below */
-.dropdownContent.bottom {
-    top: 100%;
-    left: 0;
-}
+        .dropdownContent a:hover {
+            background-color: #ddd;
+        }
 
-/* Position above when space is not enough below */
-.dropdownContent.top {
-    bottom: 100%;
-    left: 0;
-}
+    /* Default position below */
+    .dropdownContent.bottom {
+        top: 100%;
+        left: 0;
+    }
+
+    /* Position above when space is not enough below */
+    .dropdownContent.top {
+        bottom: 100%;
+        left: 0;
+    }
 
 /* *********************** Panel Toggel **************************** */
 .PlTe {
@@ -1017,9 +1036,9 @@ html, body {
     border-radius: var(--Pl10);
 }
 
-.PlTe > .PlTeCt2 {
-    display: none;
-}
+    .PlTe > .PlTeCt2 {
+        display: none;
+    }
 
 .PlTeHd {
     width: 100%;
@@ -1193,7 +1212,7 @@ html, body {
 
 .CTabScrollBnRt {
     top: 50%;
-    right:0;
+    right: 0;
 }
 
 .CTabScrollBnLt {
@@ -1677,7 +1696,7 @@ html, body {
     -ms-overflow-style: none; /* IE and Edge */
 }
 
-/*content*/ 
+/*content*/
 .NvSdDnLtRtCt {
     width: 100%;
     height: 70vh;
@@ -1691,9 +1710,9 @@ html, body {
     transition: all .2s ease;
 }
 
-.NvSdDnLtRtScrollBar::-webkit-scrollbar {
-    display: none;
-}
+    .NvSdDnLtRtScrollBar::-webkit-scrollbar {
+        display: none;
+    }
 
 /* Custom scrollbar track */
 .NvSdCmSr {
@@ -1714,7 +1733,7 @@ html, body {
     transform: translateX(-20px);
 }
 
-/*nav side custom scrollbar right*/ 
+/*nav side custom scrollbar right*/
 .NvSdCmSrRt {
     transform: translateX(20px);
     right: 2px;
@@ -1732,9 +1751,9 @@ html, body {
     transition: background-color 0.2s ease;
 }
 
-.NvSdCmSlTb:hover {
-    background: rgba(255, 255, 255, 0.6);
-}
+    .NvSdCmSlTb:hover {
+        background: rgba(255, 255, 255, 0.6);
+    }
 
 /* Show scrollbar on hover */
 /*.NvSdDnLtRtScrollBar:hover .NvSdCmSr {
@@ -1760,12 +1779,12 @@ html, body {
     background: white;
 }
 
-.NvSdLk > *,
-.NvSdSbLk > *,
-.NvSdSbSbLk > *,
-.NvSdBnLk > * {
-    padding: 0px 3px;
-}
+    .NvSdLk > *,
+    .NvSdSbLk > *,
+    .NvSdSbSbLk > *,
+    .NvSdBnLk > * {
+        padding: 0px 3px;
+    }
 
 .NvSdLk:hover,
 .NvSdSbLk:hover,
@@ -1776,11 +1795,11 @@ html, body {
     border-radius: 5px;
 }
 
-.NvSdLk:hover a,
-.NvSdSbLk:hover a,
-.NvSdSbSbLk:hover a {
-    color: var(--CrTeHrTt) !important;
-}
+    .NvSdLk:hover a,
+    .NvSdSbLk:hover a,
+    .NvSdSbSbLk:hover a {
+        color: var(--CrTeHrTt) !important;
+    }
 
 
 .NvSdLkCr {
@@ -1824,12 +1843,12 @@ html, body {
     transition: all ease-in .6s;
 }
 
-.NvSdLkAe > a,
-.NvSdLkAe > a :hover,
-.NvSdLkSbAe > a :hover,
-.NvSdLkSbSbAe > a :hover {
-    color: var(--CrTeStTt);
-}
+    .NvSdLkAe > a,
+    .NvSdLkAe > a :hover,
+    .NvSdLkSbAe > a :hover,
+    .NvSdLkSbSbAe > a :hover {
+        color: var(--CrTeStTt);
+    }
 
 .NvSdLkSbAe {
     font-weight: 600;
@@ -1837,18 +1856,18 @@ html, body {
     background-color: hsla(var(--CrTeH) 100 65% / 0.50);
 }
 
-.NvSdLkSbAe::before {
-    content: '';
-    width: 0;
-    height: 0;
-    border-top: 12px solid transparent;
-    border-left: 12px solid rgba(32, 32, 30, 0.95);
-    border-bottom: 12px solid transparent;
-    left: 0;
-    top: 0;
-    position: absolute;
-    transform: translate(-11px, 50%);
-}
+    .NvSdLkSbAe::before {
+        content: '';
+        width: 0;
+        height: 0;
+        border-top: 12px solid transparent;
+        border-left: 12px solid rgba(32, 32, 30, 0.95);
+        border-bottom: 12px solid transparent;
+        left: 0;
+        top: 0;
+        position: absolute;
+        transform: translate(-11px, 50%);
+    }
 
 .NvSdLkSbSbAe {
     font-weight: 600;
@@ -1857,18 +1876,18 @@ html, body {
     background-color: hsla(var(--CrTeH) 100% 80% /0.50);
 }
 
-.NvSdLkSbSbAe::before {
-    content: '';
-    width: 0;
-    height: 0;
-    border-top: 10px solid transparent;
-    border-left: 10px solid rgba(32, 32, 30, 0.95);
-    border-bottom: 10px solid transparent;
-    left: 0;
-    top: 0;
-    position: absolute;
-    transform: translate(-31px, 71%);
-}
+    .NvSdLkSbSbAe::before {
+        content: '';
+        width: 0;
+        height: 0;
+        border-top: 10px solid transparent;
+        border-left: 10px solid rgba(32, 32, 30, 0.95);
+        border-bottom: 10px solid transparent;
+        left: 0;
+        top: 0;
+        position: absolute;
+        transform: translate(-31px, 71%);
+    }
 
 
 .NvSdPlCe {
@@ -1911,14 +1930,14 @@ html, body {
     height: 15vh;
 }
 
-.NvSdLo > img {
-    width: auto;
-    min-height: auto;
-    height: 100%;
-    max-height: 100%;
-    max-width: 100%;
-    object-fit: contain;
-}
+    .NvSdLo > img {
+        width: auto;
+        min-height: auto;
+        height: 100%;
+        max-height: 100%;
+        max-width: 100%;
+        object-fit: contain;
+    }
 
 .NvSdDpDnCr {
     display: none;
@@ -1933,15 +1952,15 @@ html, body {
     overflow-y: auto;
 }
 
-.NvSdDpDnCr .NvSdSbSbLkCr {
-    max-height: 0px;
-}
+    .NvSdDpDnCr .NvSdSbSbLkCr {
+        max-height: 0px;
+    }
 
-.NvSdDpDnCr .NvSdSbLkCr {
-    border-left: none;
-    padding-left: 0px;
-    margin-left: 0px;
-}
+    .NvSdDpDnCr .NvSdSbLkCr {
+        border-left: none;
+        padding-left: 0px;
+        margin-left: 0px;
+    }
 
 @media (min-width:768px) {
     .NvSdSn, .NvSdSnOp {
@@ -2051,45 +2070,45 @@ html, body {
     z-index: 10000000;
 }
 
-.ToolTip::after {
-    content: '';
-    position: absolute;
-    width: 0;
-    height: 0;
-    border-style: solid;
-}
+    .ToolTip::after {
+        content: '';
+        position: absolute;
+        width: 0;
+        height: 0;
+        border-style: solid;
+    }
 
-.ToolTip.Top::after {
-    border-width: 5px 5px 0 5px;
-    border-color: var(--CrTeTlTpBd) transparent transparent transparent;
-    bottom: -4px;
-    left: var(--arrow-left);
-    transform: translateX(-50%);
-}
+    .ToolTip.Top::after {
+        border-width: 5px 5px 0 5px;
+        border-color: var(--CrTeTlTpBd) transparent transparent transparent;
+        bottom: -4px;
+        left: var(--arrow-left);
+        transform: translateX(-50%);
+    }
 
-.ToolTip.Right::after {
-    border-width: 5px 5px 5px 0;
-    border-color: transparent var(--CrTeTlTpBd) transparent transparent;
-    left: -4px;
-    top: calc(var(--arrow-top, 50%) + 0px); /* Ensure px */
-    transform: translateY(-50%);
-}
+    .ToolTip.Right::after {
+        border-width: 5px 5px 5px 0;
+        border-color: transparent var(--CrTeTlTpBd) transparent transparent;
+        left: -4px;
+        top: calc(var(--arrow-top, 50%) + 0px); /* Ensure px */
+        transform: translateY(-50%);
+    }
 
-.ToolTip.Bottom::after {
-    border-width: 0 5px 5px 5px;
-    border-color: transparent transparent var(--CrTeTlTpBd) transparent;
-    top: -5px;
-    left: var(--arrow-left);
-    transform: translateX(-50%);
-}
+    .ToolTip.Bottom::after {
+        border-width: 0 5px 5px 5px;
+        border-color: transparent transparent var(--CrTeTlTpBd) transparent;
+        top: -5px;
+        left: var(--arrow-left);
+        transform: translateX(-50%);
+    }
 
-.ToolTip.Left::after {
-    border-width: 5px 0 5px 5px;
-    border-color: transparent transparent transparent var(--CrTeTlTpBd);
-    right: -4px;
-    top: calc(var(--arrow-top, 50%) + 0px); /* Ensure px */
-    transform: translateY(-50%);
-}
+    .ToolTip.Left::after {
+        border-width: 5px 0 5px 5px;
+        border-color: transparent transparent transparent var(--CrTeTlTpBd);
+        right: -4px;
+        top: calc(var(--arrow-top, 50%) + 0px); /* Ensure px */
+        transform: translateY(-50%);
+    }
 
 /* *********************** Site Top Background Div **************************** */
 .StTpBdDv::after {
@@ -6731,7 +6750,7 @@ html, body {
 .BxSwTpRtCrPk {
     box-shadow: 8px -8px 6px -6px hsla(var(--CrPkH) 100% 50%);
 }
- 
+
 .BxSwTpRtCrYw {
     box-shadow: 8px -8px 6px -6px hsla(var(--CrYwH) 100% 50%);
 }
@@ -17327,7 +17346,7 @@ html, body {
     margin: auto;
 }
 
-.MnTpAo{
+.MnTpAo {
     margin-top: auto;
 }
 
@@ -17335,7 +17354,7 @@ html, body {
     margin-bottom: auto;
 }
 
-.MnLtAo{
+.MnLtAo {
     margin-left: auto;
 }
 
@@ -51124,7 +51143,7 @@ Extra Extra Large = EaEaLe = ≥1400px
         bottom: -25%;
     }
 
-    /*Display*/ 
+    /*Display*/
     .Sl\:DyBk {
         display: block
     }
@@ -51460,7 +51479,6 @@ Extra Extra Large = EaEaLe = ≥1400px
     .Sl\:GdTeCsRt10Fr1 {
         grid-template-columns: repeat(10, 1fr);
     }
-
 }
 
 /* Medium devices (tablets, 768px and up)*/
@@ -69714,7 +69732,6 @@ Extra Extra Large = EaEaLe = ≥1400px
     .Mm\:GdTeCsRt10Fr1 {
         grid-template-columns: repeat(10, 1fr);
     }
-
 }
 
 /* Large devices (desktops, 992px and up)*/
@@ -87979,7 +87996,6 @@ Extra Extra Large = EaEaLe = ≥1400px
     .Le\:GdTeCsRt10Fr1 {
         grid-template-columns: repeat(10, 1fr);
     }
-
 }
 
 /* X-Large devices (large desktops, 1200px and up)*/
@@ -106233,7 +106249,6 @@ Extra Extra Large = EaEaLe = ≥1400px
     .EaLe\:GdTeCsRt10Fr1 {
         grid-template-columns: repeat(10, 1fr);
     }
-
 }
 
 /* XX-Large devices (larger desktops, 1400px and up)*/
@@ -124506,7 +124521,6 @@ Extra Extra Large = EaEaLe = ≥1400px
     .EaEaLe\:GdTeCsRt10Fr1 {
         grid-template-columns: repeat(10, 1fr);
     }
-
 }
 /* *********************** Breakpoints End **************************** */
 

--- a/wwwroot/css/CelebrateStyle.css
+++ b/wwwroot/css/CelebrateStyle.css
@@ -26866,6 +26866,826 @@ html, body {
 .PnTp100p {
     top: 100%;
 }
+/*Position Negative*/
+/*Position Left*/
+.PnLtVe1 {
+    left: calc(var(--Pl1) * -1);
+}
+
+.PnLtVe2 {
+    left: calc(var(--Pl2) * -1);
+}
+
+.PnLtVe3 {
+    left: calc(var(--Pl3) * -1);
+}
+
+.PnLtVe4 {
+    left: calc(var(--Pl4) * -1);
+}
+
+.PnLtVe5 {
+    left: calc(var(--Pl5) * -1);
+}
+
+.PnLtVe6 {
+    left: calc(var(--Pl6) * -1);
+}
+
+.PnLtVe7 {
+    left: calc(var(--Pl7)* -1);
+}
+
+.PnLtVe8 {
+    left: calc(var(--Pl8)* -1);
+}
+
+.PnLtVe9 {
+    left: calc(var(--Pl9)* -1);
+}
+
+.PnLtVe10 {
+    left: calc(var(--Pl10)* -1);
+}
+
+.PnLtVe11 {
+    left: calc(var(--Pl11)* -1);
+}
+
+.PnLtVe12 {
+    left: calc(var(--Pl12)* -1);
+}
+
+.PnLtVe13 {
+    left: calc(var(--Pl13)* -1);
+}
+
+.PnLtVe14 {
+    left: calc(var(--Pl14)* -1);
+}
+
+.PnLtVe15 {
+    left: calc(var(--Pl15)* -1);
+}
+
+.PnLtVe16 {
+    left: calc(var(--Pl16)* -1);
+}
+
+.PnLtVe17 {
+    left: calc(var(--Pl17)* -1);
+}
+
+.PnLtVe18 {
+    left: calc(var(--Pl18)* -1);
+}
+
+.PnLtVe19 {
+    left: calc(var(--Pl19)* -1);
+}
+
+.PnLtVe20 {
+    left: calc(var(--Pl20)* -1);
+}
+
+.PnLtVe21 {
+    left: calc(var(--Pl21)* -1);
+}
+
+.PnLtVe22 {
+    left: calc(var(--Pl22)* -1);
+}
+
+.PnLtVe23 {
+    left: calc(var(--Pl23)* -1);
+}
+
+.PnLtVe24 {
+    left: calc(var(--Pl24)* -1);
+}
+
+.PnLtVe25 {
+    left: calc(var(--Pl25)* -1);
+}
+
+/**Position Left Percentage**/
+.PnLtVe1p {
+    left: -1%;
+}
+
+.PnLtVe2p {
+    left: -2%;
+}
+
+.PnLtVe3p {
+    left: -3%;
+}
+
+.PnLtVe4p {
+    left: -4%;
+}
+
+.PnLtVe5p {
+    left: -5%;
+}
+
+.PnLtVe6p {
+    left: -6%;
+}
+
+.PnLtVe7p {
+    left: -7%;
+}
+
+.PnLtVe8p {
+    left: -8%;
+}
+
+.PnLtVe9p {
+    left: -9%;
+}
+
+.PnLtVe10p {
+    left: -10%;
+}
+
+.PnLtVe11p {
+    left: -11%;
+}
+
+.PnLtVe12p {
+    left: -12%;
+}
+
+.PnLtVe13p {
+    left: -13%;
+}
+
+.PnLtVe14p {
+    left: -14%;
+}
+
+.PnLtVe15p {
+    left: -15%;
+}
+
+.PnLtVe16p {
+    left: -16%;
+}
+
+.PnLtVe17p {
+    left: -17%;
+}
+
+.PnLtVe18p {
+    left: -18%;
+}
+
+.PnLtVe19p {
+    left: -19%;
+}
+
+.PnLtVe20p {
+    left: -20%;
+}
+
+.PnLtVe21p {
+    left: -21%;
+}
+
+.PnLtVe22p {
+    left: -22%;
+}
+
+.PnLtVe23p {
+    left: -23%;
+}
+
+.PnLtVe24p {
+    left: -24%;
+}
+
+.PnLtVe25p {
+    left: -25%;
+}
+
+
+/**Position Right Pixel**/
+.PnRtVe1 {
+    right: calc(var(--Pl1) * -1);
+}
+
+.PnRtVe2 {
+    right: calc(var(--Pl2) * -1);
+}
+
+.PnRtVe3 {
+    right: calc(var(--Pl3) * -1);
+}
+
+.PnRtVe4 {
+    right: calc(var(--Pl4) * -1);
+}
+
+.PnRtVe5 {
+    right: calc(var(--Pl5) * -1);
+}
+
+.PnRtVe6 {
+    right: calc(var(--Pl6) * -1);
+}
+
+.PnRtVe7 {
+    right: calc(var(--Pl7)* -1);
+}
+
+.PnRtVe8 {
+    right: calc(var(--Pl8)* -1);
+}
+
+.PnRtVe9 {
+    right: calc(var(--Pl9)* -1);
+}
+
+.PnRtVe10 {
+    right: calc(var(--Pl10)* -1);
+}
+
+.PnRtVe11 {
+    right: calc(var(--Pl11)* -1);
+}
+
+.PnRtVe12 {
+    right: calc(var(--Pl12)* -1);
+}
+
+.PnRtVe13 {
+    right: calc(var(--Pl13)* -1);
+}
+
+.PnRtVe14 {
+    right: calc(var(--Pl14)* -1);
+}
+
+.PnRtVe15 {
+    right: calc(var(--Pl15)* -1);
+}
+
+.PnRtVe16 {
+    right: calc(var(--Pl16)* -1);
+}
+
+.PnRtVe17 {
+    right: calc(var(--Pl17)* -1);
+}
+
+.PnRtVe18 {
+    right: calc(var(--Pl18)* -1);
+}
+
+.PnRtVe19 {
+    right: calc(var(--Pl19)* -1);
+}
+
+.PnRtVe20 {
+    right: calc(var(--Pl20)* -1);
+}
+
+.PnRtVe21 {
+    right: calc(var(--Pl21)* -1);
+}
+
+.PnRtVe22 {
+    right: calc(var(--Pl22)* -1);
+}
+
+.PnRtVe23 {
+    right: calc(var(--Pl23)* -1);
+}
+
+.PnRtVe24 {
+    right: calc(var(--Pl24)* -1);
+}
+
+.PnRtVe25 {
+    right: calc(var(--Pl25)* -1);
+}
+
+/**Position Right percentage**/
+.PnRtVe1p {
+    right: -1%;
+}
+
+.PnRtVe2p {
+    right: -2%;
+}
+
+.PnRtVe3p {
+    right: -3%;
+}
+
+.PnRtVe4p {
+    right: -4%;
+}
+
+.PnRtVe5p {
+    right: -5%;
+}
+
+.PnRtVe6p {
+    right: -6%;
+}
+
+.PnRtVe7p {
+    right: -7%;
+}
+
+.PnRtVe8p {
+    right: -8%;
+}
+
+.PnRtVe9p {
+    right: -9%;
+}
+
+.PnRtVe10p {
+    right: -10%;
+}
+
+.PnRtVe11p {
+    right: -11%;
+}
+
+.PnRtVe12p {
+    right: -12%;
+}
+
+.PnRtVe13p {
+    right: -13%;
+}
+
+.PnRtVe14p {
+    right: -14%;
+}
+
+.PnRtVe15p {
+    right: -15%;
+}
+
+.PnRtVe16p {
+    right: -16%;
+}
+
+.PnRtVe17p {
+    right: -17%;
+}
+
+.PnRtVe18p {
+    right: -18%;
+}
+
+.PnRtVe19p {
+    right: -19%;
+}
+
+.PnRtVe20p {
+    right: -20%;
+}
+
+.PnRtVe21p {
+    right: -21%;
+}
+
+.PnRtVe22p {
+    right: -22%;
+}
+
+.PnRtVe23p {
+    right: -23%;
+}
+
+.PnRtVe24p {
+    right: -24%;
+}
+
+.PnRtVe25p {
+    right: -25%;
+}
+
+/** Position Top Pixel**/
+
+.PnTpVe1 {
+    top: calc(var(--Pl1) * -1);
+}
+
+.PnTpVe2 {
+    top: calc(var(--Pl2) * -1);
+}
+
+.PnTpVe3 {
+    top: calc(var(--Pl3) * -1);
+}
+
+.PnTpVe4 {
+    top: calc(var(--Pl4) * -1);
+}
+
+.PnTpVe5 {
+    top: calc(var(--Pl5) * -1);
+}
+
+.PnTpVe6 {
+    top: calc(var(--Pl6) * -1);
+}
+
+.PnTpVe7 {
+    top: calc(var(--Pl7)* -1);
+}
+
+.PnTpVe8 {
+    top: calc(var(--Pl8)* -1);
+}
+
+.PnTpVe9 {
+    top: calc(var(--Pl9)* -1);
+}
+
+.PnTpVe10 {
+    top: calc(var(--Pl10)* -1);
+}
+
+.PnTpVe11 {
+    top: calc(var(--Pl11)* -1);
+}
+
+.PnTpVe12 {
+    top: calc(var(--Pl12)* -1);
+}
+
+.PnTpVe13 {
+    top: calc(var(--Pl13)* -1);
+}
+
+.PnTpVe14 {
+    top: calc(var(--Pl14)* -1);
+}
+
+.PnTpVe15 {
+    top: calc(var(--Pl15)* -1);
+}
+
+.PnTpVe16 {
+    top: calc(var(--Pl16)* -1);
+}
+
+.PnTpVe17 {
+    top: calc(var(--Pl17)* -1);
+}
+
+.PnTpVe18 {
+    top: calc(var(--Pl18)* -1);
+}
+
+.PnTpVe19 {
+    top: calc(var(--Pl19)* -1);
+}
+
+.PnTpVe20 {
+    top: calc(var(--Pl20)* -1);
+}
+
+.PnTpVe21 {
+    top: calc(var(--Pl21)* -1);
+}
+
+.PnTpVe22 {
+    top: calc(var(--Pl22)* -1);
+}
+
+.PnTpVe23 {
+    top: calc(var(--Pl23)* -1);
+}
+
+.PnTpVe24 {
+    top: calc(var(--Pl24)* -1);
+}
+
+.PnTpVe25 {
+    top: calc(var(--Pl25)* -1);
+}
+
+
+
+/**Position Top Percentage**/
+.PnTpVe1p {
+    top: -1%;
+}
+
+.PnTpVe2p {
+    top: -2%;
+}
+
+.PnTpVe3p {
+    top: -3%;
+}
+
+.PnTpVe4p {
+    top: -4%;
+}
+
+.PnTpVe5p {
+    top: -5%;
+}
+
+.PnTpVe6p {
+    top: -6%;
+}
+
+.PnTpVe7p {
+    top: -7%;
+}
+
+.PnTpVe8p {
+    top: -8%;
+}
+
+.PnTpVe9p {
+    top: -9%;
+}
+
+.PnTpVe10p {
+    top: -10%;
+}
+
+.PnTpVe11p {
+    top: -11%;
+}
+
+.PnTpVe12p {
+    top: -12%;
+}
+
+.PnTpVe13p {
+    top: -13%;
+}
+
+.PnTpVe14p {
+    top: -14%;
+}
+
+.PnTpVe15p {
+    top: -15%;
+}
+
+.PnTpVe16p {
+    top: -16%;
+}
+
+.PnTpVe17p {
+    top: -17%;
+}
+
+.PnTpVe18p {
+    top: -18%;
+}
+
+.PnTpVe19p {
+    top: -19%;
+}
+
+.PnTpVe20p {
+    top: -20%;
+}
+
+.PnTpVe21p {
+    top: -21%;
+}
+
+.PnTpVe22p {
+    top: -22%;
+}
+
+.PnTpVe23p {
+    top: -23%;
+}
+
+.PnTpVe24p {
+    top: -24%;
+}
+
+.PnTpVe25p {
+    top: -25%;
+}
+
+
+
+
+/**  Position Bottom  Pixel**/
+.PnBmVe1 {
+    bottom: calc(var(--Pl1) * -1);
+}
+
+.PnBmVe2 {
+    bottom: calc(var(--Pl2) * -1);
+}
+
+.PnBmVe3 {
+    bottom: calc(var(--Pl3) * -1);
+}
+
+.PnBmVe4 {
+    bottom: calc(var(--Pl4) * -1);
+}
+
+.PnBmVe5 {
+    bottom: calc(var(--Pl5) * -1);
+}
+
+.PnBmVe6 {
+    bottom: calc(var(--Pl6) * -1);
+}
+
+.PnBmVe7 {
+    bottom: calc(var(--Pl7)* -1);
+}
+
+.PnBmVe8 {
+    bottom: calc(var(--Pl8)* -1);
+}
+
+.PnBmVe9 {
+    bottom: calc(var(--Pl9)* -1);
+}
+
+.PnBmVe10 {
+    bottom: calc(var(--Pl10)* -1);
+}
+
+.PnBmVe11 {
+    bottom: calc(var(--Pl11)* -1);
+}
+
+.PnBmVe12 {
+    bottom: calc(var(--Pl12)* -1);
+}
+
+.PnBmVe13 {
+    bottom: calc(var(--Pl13)* -1);
+}
+
+.PnBmVe14 {
+    bottom: calc(var(--Pl14)* -1);
+}
+
+.PnBmVe15 {
+    bottom: calc(var(--Pl15)* -1);
+}
+
+.PnBmVe16 {
+    bottom: calc(var(--Pl16)* -1);
+}
+
+.PnBmVe17 {
+    bottom: calc(var(--Pl17)* -1);
+}
+
+.PnBmVe18 {
+    bottom: calc(var(--Pl18)* -1);
+}
+
+.PnBmVe19 {
+    bottom: calc(var(--Pl19)* -1);
+}
+
+.PnBmVe20 {
+    bottom: calc(var(--Pl20)* -1);
+}
+
+.PnBmVe21 {
+    bottom: calc(var(--Pl21)* -1);
+}
+
+.PnBmVe22 {
+    bottom: calc(var(--Pl22)* -1);
+}
+
+.PnBmVe23 {
+    bottom: calc(var(--Pl23)* -1);
+}
+
+.PnBmVe24 {
+    bottom: calc(var(--Pl24)* -1);
+}
+
+.PnBmVe25 {
+    bottom: calc(var(--Pl25)* -1);
+}
+
+
+
+/**Position Bottom Percentage**/
+
+.PnBmVe1p {
+    bottom: -1%;
+}
+
+.PnBmVe2p {
+    bottom: -2%;
+}
+
+.PnBmVe3p {
+    bottom: -3%;
+}
+
+.PnBmVe4p {
+    bottom: -4%;
+}
+
+.PnBmVe5p {
+    bottom: -5%;
+}
+
+.PnBmVe6p {
+    bottom: -6%;
+}
+
+.PnBmVe7p {
+    bottom: -7%;
+}
+
+.PnBmVe8p {
+    bottom: -8%;
+}
+
+.PnBmVe9p {
+    bottom: -9%;
+}
+
+.PnBmVe10p {
+    bottom: -10%;
+}
+
+.PnBmVe11p {
+    bottom: -11%;
+}
+
+.PnBmVe12p {
+    bottom: -12%;
+}
+
+.PnBmVe13p {
+    bottom: -13%;
+}
+
+.PnBmVe14p {
+    bottom: -14%;
+}
+
+.PnBmVe15p {
+    bottom: -15%;
+}
+
+.PnBmVe16p {
+    bottom: -16%;
+}
+
+.PnBmVe17p {
+    bottom: -17%;
+}
+
+.PnBmVe18p {
+    bottom: -18%;
+}
+
+.PnBmVe19p {
+    bottom: -19%;
+}
+
+.PnBmVe20p {
+    bottom: -20%;
+}
+
+.PnBmVe21p {
+    bottom: -21%;
+}
+
+.PnBmVe22p {
+    bottom: -22%;
+}
+
+.PnBmVe23p {
+    bottom: -23%;
+}
+
+.PnBmVe24p {
+    bottom: -24%;
+}
+
+.PnBmVe25p {
+    bottom: -25%;
+}
+
+
 
 /*Position Inset*/
 .PnIt0 {
@@ -49495,6 +50315,814 @@ Extra Extra Large = EaEaLe = ≥1400px
     .Sl\:PnLt100p {
         left: 100%;
     }
+    /*Negaative Positions*/
+    /**Neagative Position Left**/
+    .Sl\:PnLtVe1 {
+        left: calc(var(--Pl1) * -1);
+    }
+
+    .Sl\:PnLtVe2 {
+        left: calc(var(--Pl2) * -1);
+    }
+
+    .Sl\:PnLtVe3 {
+        left: calc(var(--Pl3) * -1);
+    }
+
+    .Sl\:PnLtVe4 {
+        left: calc(var(--Pl4) * -1);
+    }
+
+    .Sl\:PnLtVe5 {
+        left: calc(var(--Pl5) * -1);
+    }
+
+    .Sl\:PnLtVe6 {
+        left: calc(var(--Pl6) * -1);
+    }
+
+    .Sl\:PnLtVe7 {
+        left: calc(var(--Pl7)* -1);
+    }
+
+    .Sl\:PnLtVe8 {
+        left: calc(var(--Pl8)* -1);
+    }
+
+    .Sl\:PnLtVe9 {
+        left: calc(var(--Pl9)* -1);
+    }
+
+    .Sl\:PnLtVe10 {
+        left: calc(var(--Pl10)* -1);
+    }
+
+    .Sl\:PnLtVe11 {
+        left: calc(var(--Pl11)* -1);
+    }
+
+    .Sl\:PnLtVe12 {
+        left: calc(var(--Pl12)* -1);
+    }
+
+    .Sl\:PnLtVe13 {
+        left: calc(var(--Pl13)* -1);
+    }
+
+    .Sl\:PnLtVe14 {
+        left: calc(var(--Pl14)* -1);
+    }
+
+    .Sl\:PnLtVe15 {
+        left: calc(var(--Pl15)* -1);
+    }
+
+    .Sl\:PnLtVe16 {
+        left: calc(var(--Pl16)* -1);
+    }
+
+    .Sl\:PnLtVe17 {
+        left: calc(var(--Pl17)* -1);
+    }
+
+    .Sl\:PnLtVe18 {
+        left: calc(var(--Pl18)* -1);
+    }
+
+    .Sl\:PnLtVe19 {
+        left: calc(var(--Pl19)* -1);
+    }
+
+    .Sl\:PnLtVe20 {
+        left: calc(var(--Pl20)* -1);
+    }
+
+    .Sl\:PnLtVe21 {
+        left: calc(var(--Pl21)* -1);
+    }
+
+    .Sl\:PnLtVe22 {
+        left: calc(var(--Pl22)* -1);
+    }
+
+    .Sl\:PnLtVe23 {
+        left: calc(var(--Pl23)* -1);
+    }
+
+    .Sl\:PnLtVe24 {
+        left: calc(var(--Pl24)* -1);
+    }
+
+    .Sl\:PnLtVe25 {
+        left: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position Left Percentage**/
+    .Sl\:PnLtVe1p {
+        left: -1%;
+    }
+
+    .Sl\:PnLtVe2p {
+        left: -2%;
+    }
+
+    .Sl\:PnLtVe3p {
+        left: -3%;
+    }
+
+    .Sl\:PnLtVe4p {
+        left: -4%;
+    }
+
+    .Sl\:PnLtVe5p {
+        left: -5%;
+    }
+
+    .Sl\:PnLtVe6p {
+        left: -6%;
+    }
+
+    .Sl\:PnLtVe7p {
+        left: -7%;
+    }
+
+    .Sl\:PnLtVe8p {
+        left: -8%;
+    }
+
+    .Sl\:PnLtVe9p {
+        left: -9%;
+    }
+
+    .Sl\:PnLtVe10p {
+        left: -10%;
+    }
+
+    .Sl\:PnLtVe11p {
+        left: -11%;
+    }
+
+    .Sl\:PnLtVe12p {
+        left: -12%;
+    }
+
+    .Sl\:PnLtVe13p {
+        left: -13%;
+    }
+
+    .Sl\:PnLtVe14p {
+        left: -14%;
+    }
+
+    .Sl\:PnLtVe15p {
+        left: -15%;
+    }
+
+    .Sl\:PnLtVe16p {
+        left: -16%;
+    }
+
+    .Sl\:PnLtVe17p {
+        left: -17%;
+    }
+
+    .Sl\:PnLtVe18p {
+        left: -18%;
+    }
+
+    .Sl\:PnLtVe19p {
+        left: -19%;
+    }
+
+    .Sl\:PnLtVe20p {
+        left: -20%;
+    }
+
+    .Sl\:PnLtVe21p {
+        left: -21%;
+    }
+
+    .Sl\:PnLtVe22p {
+        left: -22%;
+    }
+
+    .Sl\:PnLtVe23p {
+        left: -23%;
+    }
+
+    .Sl\:PnLtVe24p {
+        left: -24%;
+    }
+
+    .Sl\:PnLtVe25p {
+        left: -25%;
+    }
+    /**Negative Position right**/
+    .Sl\:PnRtVe1 {
+        right: calc(var(--Pl1) * -1);
+    }
+
+    .Sl\:PnRtVe2 {
+        right: calc(var(--Pl2) * -1);
+    }
+
+    .Sl\:PnRtVe3 {
+        right: calc(var(--Pl3) * -1);
+    }
+
+    .Sl\:PnRtVe4 {
+        right: calc(var(--Pl4) * -1);
+    }
+
+    .Sl\:PnRtVe5 {
+        right: calc(var(--Pl5) * -1);
+    }
+
+    .Sl\:PnRtVe6 {
+        right: calc(var(--Pl6) * -1);
+    }
+
+    .Sl\:PnRtVe7 {
+        right: calc(var(--Pl7)* -1);
+    }
+
+    .Sl\:PnRtVe8 {
+        right: calc(var(--Pl8)* -1);
+    }
+
+    .Sl\:PnRtVe9 {
+        right: calc(var(--Pl9)* -1);
+    }
+
+    .Sl\:PnRtVe10 {
+        right: calc(var(--Pl10)* -1);
+    }
+
+    .Sl\:PnRtVe11 {
+        right: calc(var(--Pl11)* -1);
+    }
+
+    .Sl\:PnRtVe12 {
+        right: calc(var(--Pl12)* -1);
+    }
+
+    .Sl\:PnRtVe13 {
+        right: calc(var(--Pl13)* -1);
+    }
+
+    .Sl\:PnRtVe14 {
+        right: calc(var(--Pl14)* -1);
+    }
+
+    .Sl\:PnRtVe15 {
+        right: calc(var(--Pl15)* -1);
+    }
+
+    .Sl\:PnRtVe16 {
+        right: calc(var(--Pl16)* -1);
+    }
+
+    .Sl\:PnRtVe17 {
+        right: calc(var(--Pl17)* -1);
+    }
+
+    .Sl\:PnRtVe18 {
+        right: calc(var(--Pl18)* -1);
+    }
+
+    .Sl\:PnRtVe19 {
+        right: calc(var(--Pl19)* -1);
+    }
+
+    .Sl\:PnRtVe20 {
+        right: calc(var(--Pl20)* -1);
+    }
+
+    .Sl\:PnRtVe21 {
+        right: calc(var(--Pl21)* -1);
+    }
+
+    .Sl\:PnRtVe22 {
+        right: calc(var(--Pl22)* -1);
+    }
+
+    .Sl\:PnRtVe23 {
+        right: calc(var(--Pl23)* -1);
+    }
+
+    .Sl\:PnRtVe24 {
+        right: calc(var(--Pl24)* -1);
+    }
+
+    .Sl\:PnRtVe25 {
+        right: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position right Percentage**/
+    .Sl\:PnRtVe1p {
+        right: -1%;
+    }
+
+    .Sl\:PnRtVe2p {
+        right: -2%;
+    }
+
+    .Sl\:PnRtVe3p {
+        right: -3%;
+    }
+
+    .Sl\:PnRtVe4p {
+        right: -4%;
+    }
+
+    .Sl\:PnRtVe5p {
+        right: -5%;
+    }
+
+    .Sl\:PnRtVe6p {
+        right: -6%;
+    }
+
+    .Sl\:PnRtVe7p {
+        right: -7%;
+    }
+
+    .Sl\:PnRtVe8p {
+        right: -8%;
+    }
+
+    .Sl\:PnRtVe9p {
+        right: -9%;
+    }
+
+    .Sl\:PnRtVe10p {
+        right: -10%;
+    }
+
+    .Sl\:PnRtVe11p {
+        right: -11%;
+    }
+
+    .Sl\:PnRtVe12p {
+        right: -12%;
+    }
+
+    .Sl\:PnRtVe13p {
+        right: -13%;
+    }
+
+    .Sl\:PnRtVe14p {
+        right: -14%;
+    }
+
+    .Sl\:PnRtVe15p {
+        right: -15%;
+    }
+
+    .Sl\:PnRtVe16p {
+        right: -16%;
+    }
+
+    .Sl\:PnRtVe17p {
+        right: -17%;
+    }
+
+    .Sl\:PnRtVe18p {
+        right: -18%;
+    }
+
+    .Sl\:PnRtVe19p {
+        right: -19%;
+    }
+
+    .Sl\:PnRtVe20p {
+        right: -20%;
+    }
+
+    .Sl\:PnRtVe21p {
+        right: -21%;
+    }
+
+    .Sl\:PnRtVe22p {
+        right: -22%;
+    }
+
+    .Sl\:PnRtVe23p {
+        right: -23%;
+    }
+
+    .Sl\:PnRtVe24p {
+        right: -24%;
+    }
+
+    .Sl\:PnRtVe25p {
+        right: -25%;
+    }
+
+    /**Negative Position top**/
+    .Sl\:PnTpVe1 {
+        top: calc(var(--Pl1) * -1);
+    }
+
+    .Sl\:PnTpVe2 {
+        top: calc(var(--Pl2) * -1);
+    }
+
+    .Sl\:PnTpVe3 {
+        top: calc(var(--Pl3) * -1);
+    }
+
+    .Sl\:PnTpVe4 {
+        top: calc(var(--Pl4) * -1);
+    }
+
+    .Sl\:PnTpVe5 {
+        top: calc(var(--Pl5) * -1);
+    }
+
+    .Sl\:PnTpVe6 {
+        top: calc(var(--Pl6) * -1);
+    }
+
+    .Sl\:PnTpVe7 {
+        top: calc(var(--Pl7)* -1);
+    }
+
+    .Sl\:PnTpVe8 {
+        top: calc(var(--Pl8)* -1);
+    }
+
+    .Sl\:PnTpVe9 {
+        top: calc(var(--Pl9)* -1);
+    }
+
+    .Sl\:PnTpVe10 {
+        top: calc(var(--Pl10)* -1);
+    }
+
+    .Sl\:PnTpVe11 {
+        top: calc(var(--Pl11)* -1);
+    }
+
+    .Sl\:PnTpVe12 {
+        top: calc(var(--Pl12)* -1);
+    }
+
+    .Sl\:PnTpVe13 {
+        top: calc(var(--Pl13)* -1);
+    }
+
+    .Sl\:PnTpVe14 {
+        top: calc(var(--Pl14)* -1);
+    }
+
+    .Sl\:PnTpVe15 {
+        top: calc(var(--Pl15)* -1);
+    }
+
+    .Sl\:PnTpVe16 {
+        top: calc(var(--Pl16)* -1);
+    }
+
+    .Sl\:PnTpVe17 {
+        top: calc(var(--Pl17)* -1);
+    }
+
+    .Sl\:PnTpVe18 {
+        top: calc(var(--Pl18)* -1);
+    }
+
+    .Sl\:PnTpVe19 {
+        top: calc(var(--Pl19)* -1);
+    }
+
+    .Sl\:PnTpVe20 {
+        top: calc(var(--Pl20)* -1);
+    }
+
+    .Sl\:PnTpVe21 {
+        top: calc(var(--Pl21)* -1);
+    }
+
+    .Sl\:PnTpVe22 {
+        top: calc(var(--Pl22)* -1);
+    }
+
+    .Sl\:PnTpVe23 {
+        top: calc(var(--Pl23)* -1);
+    }
+
+    .Sl\:PnTpVe24 {
+        top: calc(var(--Pl24)* -1);
+    }
+
+    .Sl\:PnTpVe25 {
+        top: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position top Percentage**/
+    .Sl\:PnTpVe1p {
+        top: -1%;
+    }
+
+    .Sl\:PnTpVe2p {
+        top: -2%;
+    }
+
+    .Sl\:PnTpVe3p {
+        top: -3%;
+    }
+
+    .Sl\:PnTpVe4p {
+        top: -4%;
+    }
+
+    .Sl\:PnTpVe5p {
+        top: -5%;
+    }
+
+    .Sl\:PnTpVe6p {
+        top: -6%;
+    }
+
+    .Sl\:PnTpVe7p {
+        top: -7%;
+    }
+
+    .Sl\:PnTpVe8p {
+        top: -8%;
+    }
+
+    .Sl\:PnTpVe9p {
+        top: -9%;
+    }
+
+    .Sl\:PnTpVe10p {
+        top: -10%;
+    }
+
+    .Sl\:PnTpVe11p {
+        top: -11%;
+    }
+
+    .Sl\:PnTpVe12p {
+        top: -12%;
+    }
+
+    .Sl\:PnTpVe13p {
+        top: -13%;
+    }
+
+    .Sl\:PnTpVe14p {
+        top: -14%;
+    }
+
+    .Sl\:PnTpVe15p {
+        top: -15%;
+    }
+
+    .Sl\:PnTpVe16p {
+        top: -16%;
+    }
+
+    .Sl\:PnTpVe17p {
+        top: -17%;
+    }
+
+    .Sl\:PnTpVe18p {
+        top: -18%;
+    }
+
+    .Sl\:PnTpVe19p {
+        top: -19%;
+    }
+
+    .Sl\:PnTpVe20p {
+        top: -20%;
+    }
+
+    .Sl\:PnTpVe21p {
+        top: -21%;
+    }
+
+    .Sl\:PnTpVe22p {
+        top: -22%;
+    }
+
+    .Sl\:PnTpVe23p {
+        top: -23%;
+    }
+
+    .Sl\:PnTpVe24p {
+        top: -24%;
+    }
+
+    .Sl\:PnTpVe25p {
+        top: -25%;
+    }
+
+
+    /**Negative Position bottom**/
+    .Sl\:PnBmVe1 {
+        bottom: calc(var(--Pl1) * -1);
+    }
+
+    .Sl\:PnBmVe2 {
+        bottom: calc(var(--Pl2) * -1);
+    }
+
+    .Sl\:PnBmVe3 {
+        bottom: calc(var(--Pl3) * -1);
+    }
+
+    .Sl\:PnBmVe4 {
+        bottom: calc(var(--Pl4) * -1);
+    }
+
+    .Sl\:PnBmVe5 {
+        bottom: calc(var(--Pl5) * -1);
+    }
+
+    .Sl\:PnBmVe6 {
+        bottom: calc(var(--Pl6) * -1);
+    }
+
+    .Sl\:PnBmVe7 {
+        bottom: calc(var(--Pl7)* -1);
+    }
+
+    .Sl\:PnBmVe8 {
+        bottom: calc(var(--Pl8)* -1);
+    }
+
+    .Sl\:PnBmVe9 {
+        bottom: calc(var(--Pl9)* -1);
+    }
+
+    .Sl\:PnBmVe10 {
+        bottom: calc(var(--Pl10)* -1);
+    }
+
+    .Sl\:PnBmVe11 {
+        bottom: calc(var(--Pl11)* -1);
+    }
+
+    .Sl\:PnBmVe12 {
+        bottom: calc(var(--Pl12)* -1);
+    }
+
+    .Sl\:PnBmVe13 {
+        bottom: calc(var(--Pl13)* -1);
+    }
+
+    .Sl\:PnBmVe14 {
+        bottom: calc(var(--Pl14)* -1);
+    }
+
+    .Sl\:PnBmVe15 {
+        bottom: calc(var(--Pl15)* -1);
+    }
+
+    .Sl\:PnBmVe16 {
+        bottom: calc(var(--Pl16)* -1);
+    }
+
+    .Sl\:PnBmVe17 {
+        bottom: calc(var(--Pl17)* -1);
+    }
+
+    .Sl\:PnBmVe18 {
+        bottom: calc(var(--Pl18)* -1);
+    }
+
+    .Sl\:PnBmVe19 {
+        bottom: calc(var(--Pl19)* -1);
+    }
+
+    .Sl\:PnBmVe20 {
+        bottom: calc(var(--Pl20)* -1);
+    }
+
+    .Sl\:PnBmVe21 {
+        bottom: calc(var(--Pl21)* -1);
+    }
+
+    .Sl\:PnBmVe22 {
+        bottom: calc(var(--Pl22)* -1);
+    }
+
+    .Sl\:PnBmVe23 {
+        bottom: calc(var(--Pl23)* -1);
+    }
+
+    .Sl\:PnBmVe24 {
+        bottom: calc(var(--Pl24)* -1);
+    }
+
+    .Sl\:PnBmVe25 {
+        bottom: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position bottom Percentage**/
+    .Sl\:PnBmVe1p {
+        bottom: -1%;
+    }
+
+    .Sl\:PnBmVe2p {
+        bottom: -2%;
+    }
+
+    .Sl\:PnBmVe3p {
+        bottom: -3%;
+    }
+
+    .Sl\:PnBmVe4p {
+        bottom: -4%;
+    }
+
+    .Sl\:PnBmVe5p {
+        bottom: -5%;
+    }
+
+    .Sl\:PnBmVe6p {
+        bottom: -6%;
+    }
+
+    .Sl\:PnBmVe7p {
+        bottom: -7%;
+    }
+
+    .Sl\:PnBmVe8p {
+        bottom: -8%;
+    }
+
+    .Sl\:PnBmVe9p {
+        bottom: -9%;
+    }
+
+    .Sl\:PnBmVe10p {
+        bottom: -10%;
+    }
+
+    .Sl\:PnBmVe11p {
+        bottom: -11%;
+    }
+
+    .Sl\:PnBmVe12p {
+        bottom: -12%;
+    }
+
+    .Sl\:PnBmVe13p {
+        bottom: -13%;
+    }
+
+    .Sl\:PnBmVe14p {
+        bottom: -14%;
+    }
+
+    .Sl\:PnBmVe15p {
+        bottom: -15%;
+    }
+
+    .Sl\:PnBmVe16p {
+        bottom: -16%;
+    }
+
+    .Sl\:PnBmVe17p {
+        bottom: -17%;
+    }
+
+    .Sl\:PnBmVe18p {
+        bottom: -18%;
+    }
+
+    .Sl\:PnBmVe19p {
+        bottom: -19%;
+    }
+
+    .Sl\:PnBmVe20p {
+        bottom: -20%;
+    }
+
+    .Sl\:PnBmVe21p {
+        bottom: -21%;
+    }
+
+    .Sl\:PnBmVe22p {
+        bottom: -22%;
+    }
+
+    .Sl\:PnBmVe23p {
+        bottom: -23%;
+    }
+
+    .Sl\:PnBmVe24p {
+        bottom: -24%;
+    }
+
+    .Sl\:PnBmVe25p {
+        bottom: -25%;
+    }
 
     /*Display*/ 
     .Sl\:DyBk {
@@ -49832,6 +51460,7 @@ Extra Extra Large = EaEaLe = ≥1400px
     .Sl\:GdTeCsRt10Fr1 {
         grid-template-columns: repeat(10, 1fr);
     }
+
 }
 
 /* Medium devices (tablets, 768px and up)*/
@@ -66941,6 +68570,813 @@ Extra Extra Large = EaEaLe = ≥1400px
 
     .Mm\:PnTp100p {
         top: 100%;
+    }
+    /*Negative Position*/
+    .Mm\:PnLtVe1 {
+        left: calc(var(--Pl1) * -1);
+    }
+
+    .Mm\:PnLtVe2 {
+        left: calc(var(--Pl2) * -1);
+    }
+
+    .Mm\:PnLtVe3 {
+        left: calc(var(--Pl3) * -1);
+    }
+
+    .Mm\:PnLtVe4 {
+        left: calc(var(--Pl4) * -1);
+    }
+
+    .Mm\:PnLtVe5 {
+        left: calc(var(--Pl5) * -1);
+    }
+
+    .Mm\:PnLtVe6 {
+        left: calc(var(--Pl6) * -1);
+    }
+
+    .Mm\:PnLtVe7 {
+        left: calc(var(--Pl7)* -1);
+    }
+
+    .Mm\:PnLtVe8 {
+        left: calc(var(--Pl8)* -1);
+    }
+
+    .Mm\:PnLtVe9 {
+        left: calc(var(--Pl9)* -1);
+    }
+
+    .Mm\:PnLtVe10 {
+        left: calc(var(--Pl10)* -1);
+    }
+
+    .Mm\:PnLtVe11 {
+        left: calc(var(--Pl11)* -1);
+    }
+
+    .Mm\:PnLtVe12 {
+        left: calc(var(--Pl12)* -1);
+    }
+
+    .Mm\:PnLtVe13 {
+        left: calc(var(--Pl13)* -1);
+    }
+
+    .Mm\:PnLtVe14 {
+        left: calc(var(--Pl14)* -1);
+    }
+
+    .Mm\:PnLtVe15 {
+        left: calc(var(--Pl15)* -1);
+    }
+
+    .Mm\:PnLtVe16 {
+        left: calc(var(--Pl16)* -1);
+    }
+
+    .Mm\:PnLtVe17 {
+        left: calc(var(--Pl17)* -1);
+    }
+
+    .Mm\:PnLtVe18 {
+        left: calc(var(--Pl18)* -1);
+    }
+
+    .Mm\:PnLtVe19 {
+        left: calc(var(--Pl19)* -1);
+    }
+
+    .Mm\:PnLtVe20 {
+        left: calc(var(--Pl20)* -1);
+    }
+
+    .Mm\:PnLtVe21 {
+        left: calc(var(--Pl21)* -1);
+    }
+
+    .Mm\:PnLtVe22 {
+        left: calc(var(--Pl22)* -1);
+    }
+
+    .Mm\:PnLtVe23 {
+        left: calc(var(--Pl23)* -1);
+    }
+
+    .Mm\:PnLtVe24 {
+        left: calc(var(--Pl24)* -1);
+    }
+
+    .Mm\:PnLtVe25 {
+        left: calc(var(--Pl25)* -1);
+    }
+
+    /**Position Left Percentage**/
+    .Mm\:PnLtVe1p {
+        left: -1%;
+    }
+
+    .Mm\:PnLtVe2p {
+        left: -2%;
+    }
+
+    .Mm\:PnLtVe3p {
+        left: -3%;
+    }
+
+    .Mm\:PnLtVe4p {
+        left: -4%;
+    }
+
+    .Mm\:PnLtVe5p {
+        left: -5%;
+    }
+
+    .Mm\:PnLtVe6p {
+        left: -6%;
+    }
+
+    .Mm\:PnLtVe7p {
+        left: -7%;
+    }
+
+    .Mm\:PnLtVe8p {
+        left: -8%;
+    }
+
+    .Mm\:PnLtVe9p {
+        left: -9%;
+    }
+
+    .Mm\:PnLtVe10p {
+        left: -10%;
+    }
+
+    .Mm\:PnLtVe11p {
+        left: -11%;
+    }
+
+    .Mm\:PnLtVe12p {
+        left: -12%;
+    }
+
+    .Mm\:PnLtVe13p {
+        left: -13%;
+    }
+
+    .Mm\:PnLtVe14p {
+        left: -14%;
+    }
+
+    .Mm\:PnLtVe15p {
+        left: -15%;
+    }
+
+    .Mm\:PnLtVe16p {
+        left: -16%;
+    }
+
+    .Mm\:PnLtVe17p {
+        left: -17%;
+    }
+
+    .Mm\:PnLtVe18p {
+        left: -18%;
+    }
+
+    .Mm\:PnLtVe19p {
+        left: -19%;
+    }
+
+    .Mm\:PnLtVe20p {
+        left: -20%;
+    }
+
+    .Mm\:PnLtVe21p {
+        left: -21%;
+    }
+
+    .Mm\:PnLtVe22p {
+        left: -22%;
+    }
+
+    .Mm\:PnLtVe23p {
+        left: -23%;
+    }
+
+    .Mm\:PnLtVe24p {
+        left: -24%;
+    }
+
+    .Mm\:PnLtVe25p {
+        left: -25%;
+    }
+    /**Negative Position right**/
+    .Mm\:PnRtVe1 {
+        right: calc(var(--Pl1) * -1);
+    }
+
+    .Mm\:PnRtVe2 {
+        right: calc(var(--Pl2) * -1);
+    }
+
+    .Mm\:PnRtVe3 {
+        right: calc(var(--Pl3) * -1);
+    }
+
+    .Mm\:PnRtVe4 {
+        right: calc(var(--Pl4) * -1);
+    }
+
+    .Mm\:PnRtVe5 {
+        right: calc(var(--Pl5) * -1);
+    }
+
+    .Mm\:PnRtVe6 {
+        right: calc(var(--Pl6) * -1);
+    }
+
+    .Mm\:PnRtVe7 {
+        right: calc(var(--Pl7)* -1);
+    }
+
+    .Mm\:PnRtVe8 {
+        right: calc(var(--Pl8)* -1);
+    }
+
+    .Mm\:PnRtVe9 {
+        right: calc(var(--Pl9)* -1);
+    }
+
+    .Mm\:PnRtVe10 {
+        right: calc(var(--Pl10)* -1);
+    }
+
+    .Mm\:PnRtVe11 {
+        right: calc(var(--Pl11)* -1);
+    }
+
+    .Mm\:PnRtVe12 {
+        right: calc(var(--Pl12)* -1);
+    }
+
+    .Mm\:PnRtVe13 {
+        right: calc(var(--Pl13)* -1);
+    }
+
+    .Mm\:PnRtVe14 {
+        right: calc(var(--Pl14)* -1);
+    }
+
+    .Mm\:PnRtVe15 {
+        right: calc(var(--Pl15)* -1);
+    }
+
+    .Mm\:PnRtVe16 {
+        right: calc(var(--Pl16)* -1);
+    }
+
+    .Mm\:PnRtVe17 {
+        right: calc(var(--Pl17)* -1);
+    }
+
+    .Mm\:PnRtVe18 {
+        right: calc(var(--Pl18)* -1);
+    }
+
+    .Mm\:PnRtVe19 {
+        right: calc(var(--Pl19)* -1);
+    }
+
+    .Mm\:PnRtVe20 {
+        right: calc(var(--Pl20)* -1);
+    }
+
+    .Mm\:PnRtVe21 {
+        right: calc(var(--Pl21)* -1);
+    }
+
+    .Mm\:PnRtVe22 {
+        right: calc(var(--Pl22)* -1);
+    }
+
+    .Mm\:PnRtVe23 {
+        right: calc(var(--Pl23)* -1);
+    }
+
+    .Mm\:PnRtVe24 {
+        right: calc(var(--Pl24)* -1);
+    }
+
+    .Mm\:PnRtVe25 {
+        right: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position right Percentage**/
+    .Mm\:PnRtVe1p {
+        right: -1%;
+    }
+
+    .Mm\:PnRtVe2p {
+        right: -2%;
+    }
+
+    .Mm\:PnRtVe3p {
+        right: -3%;
+    }
+
+    .Mm\:PnRtVe4p {
+        right: -4%;
+    }
+
+    .Mm\:PnRtVe5p {
+        right: -5%;
+    }
+
+    .Mm\:PnRtVe6p {
+        right: -6%;
+    }
+
+    .Mm\:PnRtVe7p {
+        right: -7%;
+    }
+
+    .Mm\:PnRtVe8p {
+        right: -8%;
+    }
+
+    .Mm\:PnRtVe9p {
+        right: -9%;
+    }
+
+    .Mm\:PnRtVe10p {
+        right: -10%;
+    }
+
+    .Mm\:PnRtVe11p {
+        right: -11%;
+    }
+
+    .Mm\:PnRtVe12p {
+        right: -12%;
+    }
+
+    .Mm\:PnRtVe13p {
+        right: -13%;
+    }
+
+    .Mm\:PnRtVe14p {
+        right: -14%;
+    }
+
+    .Mm\:PnRtVe15p {
+        right: -15%;
+    }
+
+    .Mm\:PnRtVe16p {
+        right: -16%;
+    }
+
+    .Mm\:PnRtVe17p {
+        right: -17%;
+    }
+
+    .Mm\:PnRtVe18p {
+        right: -18%;
+    }
+
+    .Mm\:PnRtVe19p {
+        right: -19%;
+    }
+
+    .Mm\:PnRtVe20p {
+        right: -20%;
+    }
+
+    .Mm\:PnRtVe21p {
+        right: -21%;
+    }
+
+    .Mm\:PnRtVe22p {
+        right: -22%;
+    }
+
+    .Mm\:PnRtVe23p {
+        right: -23%;
+    }
+
+    .Mm\:PnRtVe24p {
+        right: -24%;
+    }
+
+    .Mm\:PnRtVe25p {
+        right: -25%;
+    }
+
+    /**Negative Position top**/
+    .Mm\:PnTpVe1 {
+        top: calc(var(--Pl1) * -1);
+    }
+
+    .Mm\:PnTpVe2 {
+        top: calc(var(--Pl2) * -1);
+    }
+
+    .Mm\:PnTpVe3 {
+        top: calc(var(--Pl3) * -1);
+    }
+
+    .Mm\:PnTpVe4 {
+        top: calc(var(--Pl4) * -1);
+    }
+
+    .Mm\:PnTpVe5 {
+        top: calc(var(--Pl5) * -1);
+    }
+
+    .Mm\:PnTpVe6 {
+        top: calc(var(--Pl6) * -1);
+    }
+
+    .Mm\:PnTpVe7 {
+        top: calc(var(--Pl7)* -1);
+    }
+
+    .Mm\:PnTpVe8 {
+        top: calc(var(--Pl8)* -1);
+    }
+
+    .Mm\:PnTpVe9 {
+        top: calc(var(--Pl9)* -1);
+    }
+
+    .Mm\:PnTpVe10 {
+        top: calc(var(--Pl10)* -1);
+    }
+
+    .Mm\:PnTpVe11 {
+        top: calc(var(--Pl11)* -1);
+    }
+
+    .Mm\:PnTpVe12 {
+        top: calc(var(--Pl12)* -1);
+    }
+
+    .Mm\:PnTpVe13 {
+        top: calc(var(--Pl13)* -1);
+    }
+
+    .Mm\:PnTpVe14 {
+        top: calc(var(--Pl14)* -1);
+    }
+
+    .Mm\:PnTpVe15 {
+        top: calc(var(--Pl15)* -1);
+    }
+
+    .Mm\:PnTpVe16 {
+        top: calc(var(--Pl16)* -1);
+    }
+
+    .Mm\:PnTpVe17 {
+        top: calc(var(--Pl17)* -1);
+    }
+
+    .Mm\:PnTpVe18 {
+        top: calc(var(--Pl18)* -1);
+    }
+
+    .Mm\:PnTpVe19 {
+        top: calc(var(--Pl19)* -1);
+    }
+
+    .Mm\:PnTpVe20 {
+        top: calc(var(--Pl20)* -1);
+    }
+
+    .Mm\:PnTpVe21 {
+        top: calc(var(--Pl21)* -1);
+    }
+
+    .Mm\:PnTpVe22 {
+        top: calc(var(--Pl22)* -1);
+    }
+
+    .Mm\:PnTpVe23 {
+        top: calc(var(--Pl23)* -1);
+    }
+
+    .Mm\:PnTpVe24 {
+        top: calc(var(--Pl24)* -1);
+    }
+
+    .Mm\:PnTpVe25 {
+        top: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position top Percentage**/
+    .Mm\:PnTpVe1p {
+        top: -1%;
+    }
+
+    .Mm\:PnTpVe2p {
+        top: -2%;
+    }
+
+    .Mm\:PnTpVe3p {
+        top: -3%;
+    }
+
+    .Mm\:PnTpVe4p {
+        top: -4%;
+    }
+
+    .Mm\:PnTpVe5p {
+        top: -5%;
+    }
+
+    .Mm\:PnTpVe6p {
+        top: -6%;
+    }
+
+    .Mm\:PnTpVe7p {
+        top: -7%;
+    }
+
+    .Mm\:PnTpVe8p {
+        top: -8%;
+    }
+
+    .Mm\:PnTpVe9p {
+        top: -9%;
+    }
+
+    .Mm\:PnTpVe10p {
+        top: -10%;
+    }
+
+    .Mm\:PnTpVe11p {
+        top: -11%;
+    }
+
+    .Mm\:PnTpVe12p {
+        top: -12%;
+    }
+
+    .Mm\:PnTpVe13p {
+        top: -13%;
+    }
+
+    .Mm\:PnTpVe14p {
+        top: -14%;
+    }
+
+    .Mm\:PnTpVe15p {
+        top: -15%;
+    }
+
+    .Mm\:PnTpVe16p {
+        top: -16%;
+    }
+
+    .Mm\:PnTpVe17p {
+        top: -17%;
+    }
+
+    .Mm\:PnTpVe18p {
+        top: -18%;
+    }
+
+    .Mm\:PnTpVe19p {
+        top: -19%;
+    }
+
+    .Mm\:PnTpVe20p {
+        top: -20%;
+    }
+
+    .Mm\:PnTpVe21p {
+        top: -21%;
+    }
+
+    .Mm\:PnTpVe22p {
+        top: -22%;
+    }
+
+    .Mm\:PnTpVe23p {
+        top: -23%;
+    }
+
+    .Mm\:PnTpVe24p {
+        top: -24%;
+    }
+
+    .Mm\:PnTpVe25p {
+        top: -25%;
+    }
+
+
+    /**Negative Position bottom**/
+    .Mm\:PnBmVe1 {
+        bottom: calc(var(--Pl1) * -1);
+    }
+
+    .Mm\:PnBmVe2 {
+        bottom: calc(var(--Pl2) * -1);
+    }
+
+    .Mm\:PnBmVe3 {
+        bottom: calc(var(--Pl3) * -1);
+    }
+
+    .Mm\:PnBmVe4 {
+        bottom: calc(var(--Pl4) * -1);
+    }
+
+    .Mm\:PnBmVe5 {
+        bottom: calc(var(--Pl5) * -1);
+    }
+
+    .Mm\:PnBmVe6 {
+        bottom: calc(var(--Pl6) * -1);
+    }
+
+    .Mm\:PnBmVe7 {
+        bottom: calc(var(--Pl7)* -1);
+    }
+
+    .Mm\:PnBmVe8 {
+        bottom: calc(var(--Pl8)* -1);
+    }
+
+    .Mm\:PnBmVe9 {
+        bottom: calc(var(--Pl9)* -1);
+    }
+
+    .Mm\:PnBmVe10 {
+        bottom: calc(var(--Pl10)* -1);
+    }
+
+    .Mm\:PnBmVe11 {
+        bottom: calc(var(--Pl11)* -1);
+    }
+
+    .Mm\:PnBmVe12 {
+        bottom: calc(var(--Pl12)* -1);
+    }
+
+    .Mm\:PnBmVe13 {
+        bottom: calc(var(--Pl13)* -1);
+    }
+
+    .Mm\:PnBmVe14 {
+        bottom: calc(var(--Pl14)* -1);
+    }
+
+    .Mm\:PnBmVe15 {
+        bottom: calc(var(--Pl15)* -1);
+    }
+
+    .Mm\:PnBmVe16 {
+        bottom: calc(var(--Pl16)* -1);
+    }
+
+    .Mm\:PnBmVe17 {
+        bottom: calc(var(--Pl17)* -1);
+    }
+
+    .Mm\:PnBmVe18 {
+        bottom: calc(var(--Pl18)* -1);
+    }
+
+    .Mm\:PnBmVe19 {
+        bottom: calc(var(--Pl19)* -1);
+    }
+
+    .Mm\:PnBmVe20 {
+        bottom: calc(var(--Pl20)* -1);
+    }
+
+    .Mm\:PnBmVe21 {
+        bottom: calc(var(--Pl21)* -1);
+    }
+
+    .Mm\:PnBmVe22 {
+        bottom: calc(var(--Pl22)* -1);
+    }
+
+    .Mm\:PnBmVe23 {
+        bottom: calc(var(--Pl23)* -1);
+    }
+
+    .Mm\:PnBmVe24 {
+        bottom: calc(var(--Pl24)* -1);
+    }
+
+    .Mm\:PnBmVe25 {
+        bottom: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position bottom Percentage**/
+    .Mm\:PnBmVe1p {
+        bottom: -1%;
+    }
+
+    .Mm\:PnBmVe2p {
+        bottom: -2%;
+    }
+
+    .Mm\:PnBmVe3p {
+        bottom: -3%;
+    }
+
+    .Mm\:PnBmVe4p {
+        bottom: -4%;
+    }
+
+    .Mm\:PnBmVe5p {
+        bottom: -5%;
+    }
+
+    .Mm\:PnBmVe6p {
+        bottom: -6%;
+    }
+
+    .Mm\:PnBmVe7p {
+        bottom: -7%;
+    }
+
+    .Mm\:PnBmVe8p {
+        bottom: -8%;
+    }
+
+    .Mm\:PnBmVe9p {
+        bottom: -9%;
+    }
+
+    .Mm\:PnBmVe10p {
+        bottom: -10%;
+    }
+
+    .Mm\:PnBmVe11p {
+        bottom: -11%;
+    }
+
+    .Mm\:PnBmVe12p {
+        bottom: -12%;
+    }
+
+    .Mm\:PnBmVe13p {
+        bottom: -13%;
+    }
+
+    .Mm\:PnBmVe14p {
+        bottom: -14%;
+    }
+
+    .Mm\:PnBmVe15p {
+        bottom: -15%;
+    }
+
+    .Mm\:PnBmVe16p {
+        bottom: -16%;
+    }
+
+    .Mm\:PnBmVe17p {
+        bottom: -17%;
+    }
+
+    .Mm\:PnBmVe18p {
+        bottom: -18%;
+    }
+
+    .Mm\:PnBmVe19p {
+        bottom: -19%;
+    }
+
+    .Mm\:PnBmVe20p {
+        bottom: -20%;
+    }
+
+    .Mm\:PnBmVe21p {
+        bottom: -21%;
+    }
+
+    .Mm\:PnBmVe22p {
+        bottom: -22%;
+    }
+
+    .Mm\:PnBmVe23p {
+        bottom: -23%;
+    }
+
+    .Mm\:PnBmVe24p {
+        bottom: -24%;
+    }
+
+    .Mm\:PnBmVe25p {
+        bottom: -25%;
     }
 
     /* Display */
@@ -84401,7 +86837,813 @@ Extra Extra Large = EaEaLe = ≥1400px
     .Le\:PnTp100p {
         top: 100%;
     }
+    /**Negative Positions**/
+    .Le\:PnLtVe1 {
+        left: calc(var(--Pl1) * -1);
+    }
 
+    .Le\:PnLtVe2 {
+        left: calc(var(--Pl2) * -1);
+    }
+
+    .Le\:PnLtVe3 {
+        left: calc(var(--Pl3) * -1);
+    }
+
+    .Le\:PnLtVe4 {
+        left: calc(var(--Pl4) * -1);
+    }
+
+    .Le\:PnLtVe5 {
+        left: calc(var(--Pl5) * -1);
+    }
+
+    .Le\:PnLtVe6 {
+        left: calc(var(--Pl6) * -1);
+    }
+
+    .Le\:PnLtVe7 {
+        left: calc(var(--Pl7)* -1);
+    }
+
+    .Le\:PnLtVe8 {
+        left: calc(var(--Pl8)* -1);
+    }
+
+    .Le\:PnLtVe9 {
+        left: calc(var(--Pl9)* -1);
+    }
+
+    .Le\:PnLtVe10 {
+        left: calc(var(--Pl10)* -1);
+    }
+
+    .Le\:PnLtVe11 {
+        left: calc(var(--Pl11)* -1);
+    }
+
+    .Le\:PnLtVe12 {
+        left: calc(var(--Pl12)* -1);
+    }
+
+    .Le\:PnLtVe13 {
+        left: calc(var(--Pl13)* -1);
+    }
+
+    .Le\:PnLtVe14 {
+        left: calc(var(--Pl14)* -1);
+    }
+
+    .Le\:PnLtVe15 {
+        left: calc(var(--Pl15)* -1);
+    }
+
+    .Le\:PnLtVe16 {
+        left: calc(var(--Pl16)* -1);
+    }
+
+    .Le\:PnLtVe17 {
+        left: calc(var(--Pl17)* -1);
+    }
+
+    .Le\:PnLtVe18 {
+        left: calc(var(--Pl18)* -1);
+    }
+
+    .Le\:PnLtVe19 {
+        left: calc(var(--Pl19)* -1);
+    }
+
+    .Le\:PnLtVe20 {
+        left: calc(var(--Pl20)* -1);
+    }
+
+    .Le\:PnLtVe21 {
+        left: calc(var(--Pl21)* -1);
+    }
+
+    .Le\:PnLtVe22 {
+        left: calc(var(--Pl22)* -1);
+    }
+
+    .Le\:PnLtVe23 {
+        left: calc(var(--Pl23)* -1);
+    }
+
+    .Le\:PnLtVe24 {
+        left: calc(var(--Pl24)* -1);
+    }
+
+    .Le\:PnLtVe25 {
+        left: calc(var(--Pl25)* -1);
+    }
+
+    /**Position Left Percentage**/
+    .Le\:PnLtVe1p {
+        left: -1%;
+    }
+
+    .Le\:PnLtVe2p {
+        left: -2%;
+    }
+
+    .Le\:PnLtVe3p {
+        left: -3%;
+    }
+
+    .Le\:PnLtVe4p {
+        left: -4%;
+    }
+
+    .Le\:PnLtVe5p {
+        left: -5%;
+    }
+
+    .Le\:PnLtVe6p {
+        left: -6%;
+    }
+
+    .Le\:PnLtVe7p {
+        left: -7%;
+    }
+
+    .Le\:PnLtVe8p {
+        left: -8%;
+    }
+
+    .Le\:PnLtVe9p {
+        left: -9%;
+    }
+
+    .Le\:PnLtVe10p {
+        left: -10%;
+    }
+
+    .Le\:PnLtVe11p {
+        left: -11%;
+    }
+
+    .Le\:PnLtVe12p {
+        left: -12%;
+    }
+
+    .Le\:PnLtVe13p {
+        left: -13%;
+    }
+
+    .Le\:PnLtVe14p {
+        left: -14%;
+    }
+
+    .Le\:PnLtVe15p {
+        left: -15%;
+    }
+
+    .Le\:PnLtVe16p {
+        left: -16%;
+    }
+
+    .Le\:PnLtVe17p {
+        left: -17%;
+    }
+
+    .Le\:PnLtVe18p {
+        left: -18%;
+    }
+
+    .Le\:PnLtVe19p {
+        left: -19%;
+    }
+
+    .Le\:PnLtVe20p {
+        left: -20%;
+    }
+
+    .Le\:PnLtVe21p {
+        left: -21%;
+    }
+
+    .Le\:PnLtVe22p {
+        left: -22%;
+    }
+
+    .Le\:PnLtVe23p {
+        left: -23%;
+    }
+
+    .Le\:PnLtVe24p {
+        left: -24%;
+    }
+
+    .Le\:PnLtVe25p {
+        left: -25%;
+    }
+    /**Negative Position right**/
+    .Le\:PnRtVe1 {
+        right: calc(var(--Pl1) * -1);
+    }
+
+    .Le\:PnRtVe2 {
+        right: calc(var(--Pl2) * -1);
+    }
+
+    .Le\:PnRtVe3 {
+        right: calc(var(--Pl3) * -1);
+    }
+
+    .Le\:PnRtVe4 {
+        right: calc(var(--Pl4) * -1);
+    }
+
+    .Le\:PnRtVe5 {
+        right: calc(var(--Pl5) * -1);
+    }
+
+    .Le\:PnRtVe6 {
+        right: calc(var(--Pl6) * -1);
+    }
+
+    .Le\:PnRtVe7 {
+        right: calc(var(--Pl7)* -1);
+    }
+
+    .Le\:PnRtVe8 {
+        right: calc(var(--Pl8)* -1);
+    }
+
+    .Le\:PnRtVe9 {
+        right: calc(var(--Pl9)* -1);
+    }
+
+    .Le\:PnRtVe10 {
+        right: calc(var(--Pl10)* -1);
+    }
+
+    .Le\:PnRtVe11 {
+        right: calc(var(--Pl11)* -1);
+    }
+
+    .Le\:PnRtVe12 {
+        right: calc(var(--Pl12)* -1);
+    }
+
+    .Le\:PnRtVe13 {
+        right: calc(var(--Pl13)* -1);
+    }
+
+    .Le\:PnRtVe14 {
+        right: calc(var(--Pl14)* -1);
+    }
+
+    .Le\:PnRtVe15 {
+        right: calc(var(--Pl15)* -1);
+    }
+
+    .Le\:PnRtVe16 {
+        right: calc(var(--Pl16)* -1);
+    }
+
+    .Le\:PnRtVe17 {
+        right: calc(var(--Pl17)* -1);
+    }
+
+    .Le\:PnRtVe18 {
+        right: calc(var(--Pl18)* -1);
+    }
+
+    .Le\:PnRtVe19 {
+        right: calc(var(--Pl19)* -1);
+    }
+
+    .Le\:PnRtVe20 {
+        right: calc(var(--Pl20)* -1);
+    }
+
+    .Le\:PnRtVe21 {
+        right: calc(var(--Pl21)* -1);
+    }
+
+    .Le\:PnRtVe22 {
+        right: calc(var(--Pl22)* -1);
+    }
+
+    .Le\:PnRtVe23 {
+        right: calc(var(--Pl23)* -1);
+    }
+
+    .Le\:PnRtVe24 {
+        right: calc(var(--Pl24)* -1);
+    }
+
+    .Le\:PnRtVe25 {
+        right: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position right Percentage**/
+    .Le\:PnRtVe1p {
+        right: -1%;
+    }
+
+    .Le\:PnRtVe2p {
+        right: -2%;
+    }
+
+    .Le\:PnRtVe3p {
+        right: -3%;
+    }
+
+    .Le\:PnRtVe4p {
+        right: -4%;
+    }
+
+    .Le\:PnRtVe5p {
+        right: -5%;
+    }
+
+    .Le\:PnRtVe6p {
+        right: -6%;
+    }
+
+    .Le\:PnRtVe7p {
+        right: -7%;
+    }
+
+    .Le\:PnRtVe8p {
+        right: -8%;
+    }
+
+    .Le\:PnRtVe9p {
+        right: -9%;
+    }
+
+    .Le\:PnRtVe10p {
+        right: -10%;
+    }
+
+    .Le\:PnRtVe11p {
+        right: -11%;
+    }
+
+    .Le\:PnRtVe12p {
+        right: -12%;
+    }
+
+    .Le\:PnRtVe13p {
+        right: -13%;
+    }
+
+    .Le\:PnRtVe14p {
+        right: -14%;
+    }
+
+    .Le\:PnRtVe15p {
+        right: -15%;
+    }
+
+    .Le\:PnRtVe16p {
+        right: -16%;
+    }
+
+    .Le\:PnRtVe17p {
+        right: -17%;
+    }
+
+    .Le\:PnRtVe18p {
+        right: -18%;
+    }
+
+    .Le\:PnRtVe19p {
+        right: -19%;
+    }
+
+    .Le\:PnRtVe20p {
+        right: -20%;
+    }
+
+    .Le\:PnRtVe21p {
+        right: -21%;
+    }
+
+    .Le\:PnRtVe22p {
+        right: -22%;
+    }
+
+    .Le\:PnRtVe23p {
+        right: -23%;
+    }
+
+    .Le\:PnRtVe24p {
+        right: -24%;
+    }
+
+    .Le\:PnRtVe25p {
+        right: -25%;
+    }
+
+    /**Negative Position top**/
+    .Le\:PnTpVe1 {
+        top: calc(var(--Pl1) * -1);
+    }
+
+    .Le\:PnTpVe2 {
+        top: calc(var(--Pl2) * -1);
+    }
+
+    .Le\:PnTpVe3 {
+        top: calc(var(--Pl3) * -1);
+    }
+
+    .Le\:PnTpVe4 {
+        top: calc(var(--Pl4) * -1);
+    }
+
+    .Le\:PnTpVe5 {
+        top: calc(var(--Pl5) * -1);
+    }
+
+    .Le\:PnTpVe6 {
+        top: calc(var(--Pl6) * -1);
+    }
+
+    .Le\:PnTpVe7 {
+        top: calc(var(--Pl7)* -1);
+    }
+
+    .Le\:PnTpVe8 {
+        top: calc(var(--Pl8)* -1);
+    }
+
+    .Le\:PnTpVe9 {
+        top: calc(var(--Pl9)* -1);
+    }
+
+    .Le\:PnTpVe10 {
+        top: calc(var(--Pl10)* -1);
+    }
+
+    .Le\:PnTpVe11 {
+        top: calc(var(--Pl11)* -1);
+    }
+
+    .Le\:PnTpVe12 {
+        top: calc(var(--Pl12)* -1);
+    }
+
+    .Le\:PnTpVe13 {
+        top: calc(var(--Pl13)* -1);
+    }
+
+    .Le\:PnTpVe14 {
+        top: calc(var(--Pl14)* -1);
+    }
+
+    .Le\:PnTpVe15 {
+        top: calc(var(--Pl15)* -1);
+    }
+
+    .Le\:PnTpVe16 {
+        top: calc(var(--Pl16)* -1);
+    }
+
+    .Le\:PnTpVe17 {
+        top: calc(var(--Pl17)* -1);
+    }
+
+    .Le\:PnTpVe18 {
+        top: calc(var(--Pl18)* -1);
+    }
+
+    .Le\:PnTpVe19 {
+        top: calc(var(--Pl19)* -1);
+    }
+
+    .Le\:PnTpVe20 {
+        top: calc(var(--Pl20)* -1);
+    }
+
+    .Le\:PnTpVe21 {
+        top: calc(var(--Pl21)* -1);
+    }
+
+    .Le\:PnTpVe22 {
+        top: calc(var(--Pl22)* -1);
+    }
+
+    .Le\:PnTpVe23 {
+        top: calc(var(--Pl23)* -1);
+    }
+
+    .Le\:PnTpVe24 {
+        top: calc(var(--Pl24)* -1);
+    }
+
+    .Le\:PnTpVe25 {
+        top: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position top Percentage**/
+    .Le\:PnTpVe1p {
+        top: -1%;
+    }
+
+    .Le\:PnTpVe2p {
+        top: -2%;
+    }
+
+    .Le\:PnTpVe3p {
+        top: -3%;
+    }
+
+    .Le\:PnTpVe4p {
+        top: -4%;
+    }
+
+    .Le\:PnTpVe5p {
+        top: -5%;
+    }
+
+    .Le\:PnTpVe6p {
+        top: -6%;
+    }
+
+    .Le\:PnTpVe7p {
+        top: -7%;
+    }
+
+    .Le\:PnTpVe8p {
+        top: -8%;
+    }
+
+    .Le\:PnTpVe9p {
+        top: -9%;
+    }
+
+    .Le\:PnTpVe10p {
+        top: -10%;
+    }
+
+    .Le\:PnTpVe11p {
+        top: -11%;
+    }
+
+    .Le\:PnTpVe12p {
+        top: -12%;
+    }
+
+    .Le\:PnTpVe13p {
+        top: -13%;
+    }
+
+    .Le\:PnTpVe14p {
+        top: -14%;
+    }
+
+    .Le\:PnTpVe15p {
+        top: -15%;
+    }
+
+    .Le\:PnTpVe16p {
+        top: -16%;
+    }
+
+    .Le\:PnTpVe17p {
+        top: -17%;
+    }
+
+    .Le\:PnTpVe18p {
+        top: -18%;
+    }
+
+    .Le\:PnTpVe19p {
+        top: -19%;
+    }
+
+    .Le\:PnTpVe20p {
+        top: -20%;
+    }
+
+    .Le\:PnTpVe21p {
+        top: -21%;
+    }
+
+    .Le\:PnTpVe22p {
+        top: -22%;
+    }
+
+    .Le\:PnTpVe23p {
+        top: -23%;
+    }
+
+    .Le\:PnTpVe24p {
+        top: -24%;
+    }
+
+    .Le\:PnTpVe25p {
+        top: -25%;
+    }
+
+
+    /**Negative Position bottom**/
+    .Le\:PnBmVe1 {
+        bottom: calc(var(--Pl1) * -1);
+    }
+
+    .Le\:PnBmVe2 {
+        bottom: calc(var(--Pl2) * -1);
+    }
+
+    .Le\:PnBmVe3 {
+        bottom: calc(var(--Pl3) * -1);
+    }
+
+    .Le\:PnBmVe4 {
+        bottom: calc(var(--Pl4) * -1);
+    }
+
+    .Le\:PnBmVe5 {
+        bottom: calc(var(--Pl5) * -1);
+    }
+
+    .Le\:PnBmVe6 {
+        bottom: calc(var(--Pl6) * -1);
+    }
+
+    .Le\:PnBmVe7 {
+        bottom: calc(var(--Pl7)* -1);
+    }
+
+    .Le\:PnBmVe8 {
+        bottom: calc(var(--Pl8)* -1);
+    }
+
+    .Le\:PnBmVe9 {
+        bottom: calc(var(--Pl9)* -1);
+    }
+
+    .Le\:PnBmVe10 {
+        bottom: calc(var(--Pl10)* -1);
+    }
+
+    .Le\:PnBmVe11 {
+        bottom: calc(var(--Pl11)* -1);
+    }
+
+    .Le\:PnBmVe12 {
+        bottom: calc(var(--Pl12)* -1);
+    }
+
+    .Le\:PnBmVe13 {
+        bottom: calc(var(--Pl13)* -1);
+    }
+
+    .Le\:PnBmVe14 {
+        bottom: calc(var(--Pl14)* -1);
+    }
+
+    .Le\:PnBmVe15 {
+        bottom: calc(var(--Pl15)* -1);
+    }
+
+    .Le\:PnBmVe16 {
+        bottom: calc(var(--Pl16)* -1);
+    }
+
+    .Le\:PnBmVe17 {
+        bottom: calc(var(--Pl17)* -1);
+    }
+
+    .Le\:PnBmVe18 {
+        bottom: calc(var(--Pl18)* -1);
+    }
+
+    .Le\:PnBmVe19 {
+        bottom: calc(var(--Pl19)* -1);
+    }
+
+    .Le\:PnBmVe20 {
+        bottom: calc(var(--Pl20)* -1);
+    }
+
+    .Le\:PnBmVe21 {
+        bottom: calc(var(--Pl21)* -1);
+    }
+
+    .Le\:PnBmVe22 {
+        bottom: calc(var(--Pl22)* -1);
+    }
+
+    .Le\:PnBmVe23 {
+        bottom: calc(var(--Pl23)* -1);
+    }
+
+    .Le\:PnBmVe24 {
+        bottom: calc(var(--Pl24)* -1);
+    }
+
+    .Le\:PnBmVe25 {
+        bottom: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position bottom Percentage**/
+    .Le\:PnBmVe1p {
+        bottom: -1%;
+    }
+
+    .Le\:PnBmVe2p {
+        bottom: -2%;
+    }
+
+    .Le\:PnBmVe3p {
+        bottom: -3%;
+    }
+
+    .Le\:PnBmVe4p {
+        bottom: -4%;
+    }
+
+    .Le\:PnBmVe5p {
+        bottom: -5%;
+    }
+
+    .Le\:PnBmVe6p {
+        bottom: -6%;
+    }
+
+    .Le\:PnBmVe7p {
+        bottom: -7%;
+    }
+
+    .Le\:PnBmVe8p {
+        bottom: -8%;
+    }
+
+    .Le\:PnBmVe9p {
+        bottom: -9%;
+    }
+
+    .Le\:PnBmVe10p {
+        bottom: -10%;
+    }
+
+    .Le\:PnBmVe11p {
+        bottom: -11%;
+    }
+
+    .Le\:PnBmVe12p {
+        bottom: -12%;
+    }
+
+    .Le\:PnBmVe13p {
+        bottom: -13%;
+    }
+
+    .Le\:PnBmVe14p {
+        bottom: -14%;
+    }
+
+    .Le\:PnBmVe15p {
+        bottom: -15%;
+    }
+
+    .Le\:PnBmVe16p {
+        bottom: -16%;
+    }
+
+    .Le\:PnBmVe17p {
+        bottom: -17%;
+    }
+
+    .Le\:PnBmVe18p {
+        bottom: -18%;
+    }
+
+    .Le\:PnBmVe19p {
+        bottom: -19%;
+    }
+
+    .Le\:PnBmVe20p {
+        bottom: -20%;
+    }
+
+    .Le\:PnBmVe21p {
+        bottom: -21%;
+    }
+
+    .Le\:PnBmVe22p {
+        bottom: -22%;
+    }
+
+    .Le\:PnBmVe23p {
+        bottom: -23%;
+    }
+
+    .Le\:PnBmVe24p {
+        bottom: -24%;
+    }
+
+    .Le\:PnBmVe25p {
+        bottom: -25%;
+    }
     /* Display */
     .Le\:DyBk {
         display: block
@@ -101849,7 +105091,813 @@ Extra Extra Large = EaEaLe = ≥1400px
     .EaLe\:PnTp100p {
         top: 100%;
     }
+    /**Neagative Positions**/
+    .EaLe\:PnLtVe1 {
+        left: calc(var(--Pl1) * -1);
+    }
 
+    .EaLe\:PnLtVe2 {
+        left: calc(var(--Pl2) * -1);
+    }
+
+    .EaLe\:PnLtVe3 {
+        left: calc(var(--Pl3) * -1);
+    }
+
+    .EaLe\:PnLtVe4 {
+        left: calc(var(--Pl4) * -1);
+    }
+
+    .EaLe\:PnLtVe5 {
+        left: calc(var(--Pl5) * -1);
+    }
+
+    .EaLe\:PnLtVe6 {
+        left: calc(var(--Pl6) * -1);
+    }
+
+    .EaLe\:PnLtVe7 {
+        left: calc(var(--Pl7)* -1);
+    }
+
+    .EaLe\:PnLtVe8 {
+        left: calc(var(--Pl8)* -1);
+    }
+
+    .EaLe\:PnLtVe9 {
+        left: calc(var(--Pl9)* -1);
+    }
+
+    .EaLe\:PnLtVe10 {
+        left: calc(var(--Pl10)* -1);
+    }
+
+    .EaLe\:PnLtVe11 {
+        left: calc(var(--Pl11)* -1);
+    }
+
+    .EaLe\:PnLtVe12 {
+        left: calc(var(--Pl12)* -1);
+    }
+
+    .EaLe\:PnLtVe13 {
+        left: calc(var(--Pl13)* -1);
+    }
+
+    .EaLe\:PnLtVe14 {
+        left: calc(var(--Pl14)* -1);
+    }
+
+    .EaLe\:PnLtVe15 {
+        left: calc(var(--Pl15)* -1);
+    }
+
+    .EaLe\:PnLtVe16 {
+        left: calc(var(--Pl16)* -1);
+    }
+
+    .EaLe\:PnLtVe17 {
+        left: calc(var(--Pl17)* -1);
+    }
+
+    .EaLe\:PnLtVe18 {
+        left: calc(var(--Pl18)* -1);
+    }
+
+    .EaLe\:PnLtVe19 {
+        left: calc(var(--Pl19)* -1);
+    }
+
+    .EaLe\:PnLtVe20 {
+        left: calc(var(--Pl20)* -1);
+    }
+
+    .EaLe\:PnLtVe21 {
+        left: calc(var(--Pl21)* -1);
+    }
+
+    .EaLe\:PnLtVe22 {
+        left: calc(var(--Pl22)* -1);
+    }
+
+    .EaLe\:PnLtVe23 {
+        left: calc(var(--Pl23)* -1);
+    }
+
+    .EaLe\:PnLtVe24 {
+        left: calc(var(--Pl24)* -1);
+    }
+
+    .EaLe\:PnLtVe25 {
+        left: calc(var(--Pl25)* -1);
+    }
+
+    /**Position Left Percentage**/
+    .EaLe\:PnLtVe1p {
+        left: -1%;
+    }
+
+    .EaLe\:PnLtVe2p {
+        left: -2%;
+    }
+
+    .EaLe\:PnLtVe3p {
+        left: -3%;
+    }
+
+    .EaLe\:PnLtVe4p {
+        left: -4%;
+    }
+
+    .EaLe\:PnLtVe5p {
+        left: -5%;
+    }
+
+    .EaLe\:PnLtVe6p {
+        left: -6%;
+    }
+
+    .EaLe\:PnLtVe7p {
+        left: -7%;
+    }
+
+    .EaLe\:PnLtVe8p {
+        left: -8%;
+    }
+
+    .EaLe\:PnLtVe9p {
+        left: -9%;
+    }
+
+    .EaLe\:PnLtVe10p {
+        left: -10%;
+    }
+
+    .EaLe\:PnLtVe11p {
+        left: -11%;
+    }
+
+    .EaLe\:PnLtVe12p {
+        left: -12%;
+    }
+
+    .EaLe\:PnLtVe13p {
+        left: -13%;
+    }
+
+    .EaLe\:PnLtVe14p {
+        left: -14%;
+    }
+
+    .EaLe\:PnLtVe15p {
+        left: -15%;
+    }
+
+    .EaLe\:PnLtVe16p {
+        left: -16%;
+    }
+
+    .EaLe\:PnLtVe17p {
+        left: -17%;
+    }
+
+    .EaLe\:PnLtVe18p {
+        left: -18%;
+    }
+
+    .EaLe\:PnLtVe19p {
+        left: -19%;
+    }
+
+    .EaLe\:PnLtVe20p {
+        left: -20%;
+    }
+
+    .EaLe\:PnLtVe21p {
+        left: -21%;
+    }
+
+    .EaLe\:PnLtVe22p {
+        left: -22%;
+    }
+
+    .EaLe\:PnLtVe23p {
+        left: -23%;
+    }
+
+    .EaLe\:PnLtVe24p {
+        left: -24%;
+    }
+
+    .EaLe\:PnLtVe25p {
+        left: -25%;
+    }
+    /**Negative Position right**/
+    .EaLe\:PnRtVe1 {
+        right: calc(var(--Pl1) * -1);
+    }
+
+    .EaLe\:PnRtVe2 {
+        right: calc(var(--Pl2) * -1);
+    }
+
+    .EaLe\:PnRtVe3 {
+        right: calc(var(--Pl3) * -1);
+    }
+
+    .EaLe\:PnRtVe4 {
+        right: calc(var(--Pl4) * -1);
+    }
+
+    .EaLe\:PnRtVe5 {
+        right: calc(var(--Pl5) * -1);
+    }
+
+    .EaLe\:PnRtVe6 {
+        right: calc(var(--Pl6) * -1);
+    }
+
+    .EaLe\:PnRtVe7 {
+        right: calc(var(--Pl7)* -1);
+    }
+
+    .EaLe\:PnRtVe8 {
+        right: calc(var(--Pl8)* -1);
+    }
+
+    .EaLe\:PnRtVe9 {
+        right: calc(var(--Pl9)* -1);
+    }
+
+    .EaLe\:PnRtVe10 {
+        right: calc(var(--Pl10)* -1);
+    }
+
+    .EaLe\:PnRtVe11 {
+        right: calc(var(--Pl11)* -1);
+    }
+
+    .EaLe\:PnRtVe12 {
+        right: calc(var(--Pl12)* -1);
+    }
+
+    .EaLe\:PnRtVe13 {
+        right: calc(var(--Pl13)* -1);
+    }
+
+    .EaLe\:PnRtVe14 {
+        right: calc(var(--Pl14)* -1);
+    }
+
+    .EaLe\:PnRtVe15 {
+        right: calc(var(--Pl15)* -1);
+    }
+
+    .EaLe\:PnRtVe16 {
+        right: calc(var(--Pl16)* -1);
+    }
+
+    .EaLe\:PnRtVe17 {
+        right: calc(var(--Pl17)* -1);
+    }
+
+    .EaLe\:PnRtVe18 {
+        right: calc(var(--Pl18)* -1);
+    }
+
+    .EaLe\:PnRtVe19 {
+        right: calc(var(--Pl19)* -1);
+    }
+
+    .EaLe\:PnRtVe20 {
+        right: calc(var(--Pl20)* -1);
+    }
+
+    .EaLe\:PnRtVe21 {
+        right: calc(var(--Pl21)* -1);
+    }
+
+    .EaLe\:PnRtVe22 {
+        right: calc(var(--Pl22)* -1);
+    }
+
+    .EaLe\:PnRtVe23 {
+        right: calc(var(--Pl23)* -1);
+    }
+
+    .EaLe\:PnRtVe24 {
+        right: calc(var(--Pl24)* -1);
+    }
+
+    .EaLe\:PnRtVe25 {
+        right: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position right Percentage**/
+    .EaLe\:PnRtVe1p {
+        right: -1%;
+    }
+
+    .EaLe\:PnRtVe2p {
+        right: -2%;
+    }
+
+    .EaLe\:PnRtVe3p {
+        right: -3%;
+    }
+
+    .EaLe\:PnRtVe4p {
+        right: -4%;
+    }
+
+    .EaLe\:PnRtVe5p {
+        right: -5%;
+    }
+
+    .EaLe\:PnRtVe6p {
+        right: -6%;
+    }
+
+    .EaLe\:PnRtVe7p {
+        right: -7%;
+    }
+
+    .EaLe\:PnRtVe8p {
+        right: -8%;
+    }
+
+    .EaLe\:PnRtVe9p {
+        right: -9%;
+    }
+
+    .EaLe\:PnRtVe10p {
+        right: -10%;
+    }
+
+    .EaLe\:PnRtVe11p {
+        right: -11%;
+    }
+
+    .EaLe\:PnRtVe12p {
+        right: -12%;
+    }
+
+    .EaLe\:PnRtVe13p {
+        right: -13%;
+    }
+
+    .EaLe\:PnRtVe14p {
+        right: -14%;
+    }
+
+    .EaLe\:PnRtVe15p {
+        right: -15%;
+    }
+
+    .EaLe\:PnRtVe16p {
+        right: -16%;
+    }
+
+    .EaLe\:PnRtVe17p {
+        right: -17%;
+    }
+
+    .EaLe\:PnRtVe18p {
+        right: -18%;
+    }
+
+    .EaLe\:PnRtVe19p {
+        right: -19%;
+    }
+
+    .EaLe\:PnRtVe20p {
+        right: -20%;
+    }
+
+    .EaLe\:PnRtVe21p {
+        right: -21%;
+    }
+
+    .EaLe\:PnRtVe22p {
+        right: -22%;
+    }
+
+    .EaLe\:PnRtVe23p {
+        right: -23%;
+    }
+
+    .EaLe\:PnRtVe24p {
+        right: -24%;
+    }
+
+    .EaLe\:PnRtVe25p {
+        right: -25%;
+    }
+
+    /**Negative Position top**/
+    .EaLe\:PnTpVe1 {
+        top: calc(var(--Pl1) * -1);
+    }
+
+    .EaLe\:PnTpVe2 {
+        top: calc(var(--Pl2) * -1);
+    }
+
+    .EaLe\:PnTpVe3 {
+        top: calc(var(--Pl3) * -1);
+    }
+
+    .EaLe\:PnTpVe4 {
+        top: calc(var(--Pl4) * -1);
+    }
+
+    .EaLe\:PnTpVe5 {
+        top: calc(var(--Pl5) * -1);
+    }
+
+    .EaLe\:PnTpVe6 {
+        top: calc(var(--Pl6) * -1);
+    }
+
+    .EaLe\:PnTpVe7 {
+        top: calc(var(--Pl7)* -1);
+    }
+
+    .EaLe\:PnTpVe8 {
+        top: calc(var(--Pl8)* -1);
+    }
+
+    .EaLe\:PnTpVe9 {
+        top: calc(var(--Pl9)* -1);
+    }
+
+    .EaLe\:PnTpVe10 {
+        top: calc(var(--Pl10)* -1);
+    }
+
+    .EaLe\:PnTpVe11 {
+        top: calc(var(--Pl11)* -1);
+    }
+
+    .EaLe\:PnTpVe12 {
+        top: calc(var(--Pl12)* -1);
+    }
+
+    .EaLe\:PnTpVe13 {
+        top: calc(var(--Pl13)* -1);
+    }
+
+    .EaLe\:PnTpVe14 {
+        top: calc(var(--Pl14)* -1);
+    }
+
+    .EaLe\:PnTpVe15 {
+        top: calc(var(--Pl15)* -1);
+    }
+
+    .EaLe\:PnTpVe16 {
+        top: calc(var(--Pl16)* -1);
+    }
+
+    .EaLe\:PnTpVe17 {
+        top: calc(var(--Pl17)* -1);
+    }
+
+    .EaLe\:PnTpVe18 {
+        top: calc(var(--Pl18)* -1);
+    }
+
+    .EaLe\:PnTpVe19 {
+        top: calc(var(--Pl19)* -1);
+    }
+
+    .EaLe\:PnTpVe20 {
+        top: calc(var(--Pl20)* -1);
+    }
+
+    .EaLe\:PnTpVe21 {
+        top: calc(var(--Pl21)* -1);
+    }
+
+    .EaLe\:PnTpVe22 {
+        top: calc(var(--Pl22)* -1);
+    }
+
+    .EaLe\:PnTpVe23 {
+        top: calc(var(--Pl23)* -1);
+    }
+
+    .EaLe\:PnTpVe24 {
+        top: calc(var(--Pl24)* -1);
+    }
+
+    .EaLe\:PnTpVe25 {
+        top: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position top Percentage**/
+    .EaLe\:PnTpVe1p {
+        top: -1%;
+    }
+
+    .EaLe\:PnTpVe2p {
+        top: -2%;
+    }
+
+    .EaLe\:PnTpVe3p {
+        top: -3%;
+    }
+
+    .EaLe\:PnTpVe4p {
+        top: -4%;
+    }
+
+    .EaLe\:PnTpVe5p {
+        top: -5%;
+    }
+
+    .EaLe\:PnTpVe6p {
+        top: -6%;
+    }
+
+    .EaLe\:PnTpVe7p {
+        top: -7%;
+    }
+
+    .EaLe\:PnTpVe8p {
+        top: -8%;
+    }
+
+    .EaLe\:PnTpVe9p {
+        top: -9%;
+    }
+
+    .EaLe\:PnTpVe10p {
+        top: -10%;
+    }
+
+    .EaLe\:PnTpVe11p {
+        top: -11%;
+    }
+
+    .EaLe\:PnTpVe12p {
+        top: -12%;
+    }
+
+    .EaLe\:PnTpVe13p {
+        top: -13%;
+    }
+
+    .EaLe\:PnTpVe14p {
+        top: -14%;
+    }
+
+    .EaLe\:PnTpVe15p {
+        top: -15%;
+    }
+
+    .EaLe\:PnTpVe16p {
+        top: -16%;
+    }
+
+    .EaLe\:PnTpVe17p {
+        top: -17%;
+    }
+
+    .EaLe\:PnTpVe18p {
+        top: -18%;
+    }
+
+    .EaLe\:PnTpVe19p {
+        top: -19%;
+    }
+
+    .EaLe\:PnTpVe20p {
+        top: -20%;
+    }
+
+    .EaLe\:PnTpVe21p {
+        top: -21%;
+    }
+
+    .EaLe\:PnTpVe22p {
+        top: -22%;
+    }
+
+    .EaLe\:PnTpVe23p {
+        top: -23%;
+    }
+
+    .EaLe\:PnTpVe24p {
+        top: -24%;
+    }
+
+    .EaLe\:PnTpVe25p {
+        top: -25%;
+    }
+
+
+    /**Negative Position bottom**/
+    .EaLe\:PnBmVe1 {
+        bottom: calc(var(--Pl1) * -1);
+    }
+
+    .EaLe\:PnBmVe2 {
+        bottom: calc(var(--Pl2) * -1);
+    }
+
+    .EaLe\:PnBmVe3 {
+        bottom: calc(var(--Pl3) * -1);
+    }
+
+    .EaLe\:PnBmVe4 {
+        bottom: calc(var(--Pl4) * -1);
+    }
+
+    .EaLe\:PnBmVe5 {
+        bottom: calc(var(--Pl5) * -1);
+    }
+
+    .EaLe\:PnBmVe6 {
+        bottom: calc(var(--Pl6) * -1);
+    }
+
+    .EaLe\:PnBmVe7 {
+        bottom: calc(var(--Pl7)* -1);
+    }
+
+    .EaLe\:PnBmVe8 {
+        bottom: calc(var(--Pl8)* -1);
+    }
+
+    .EaLe\:PnBmVe9 {
+        bottom: calc(var(--Pl9)* -1);
+    }
+
+    .EaLe\:PnBmVe10 {
+        bottom: calc(var(--Pl10)* -1);
+    }
+
+    .EaLe\:PnBmVe11 {
+        bottom: calc(var(--Pl11)* -1);
+    }
+
+    .EaLe\:PnBmVe12 {
+        bottom: calc(var(--Pl12)* -1);
+    }
+
+    .EaLe\:PnBmVe13 {
+        bottom: calc(var(--Pl13)* -1);
+    }
+
+    .EaLe\:PnBmVe14 {
+        bottom: calc(var(--Pl14)* -1);
+    }
+
+    .EaLe\:PnBmVe15 {
+        bottom: calc(var(--Pl15)* -1);
+    }
+
+    .EaLe\:PnBmVe16 {
+        bottom: calc(var(--Pl16)* -1);
+    }
+
+    .EaLe\:PnBmVe17 {
+        bottom: calc(var(--Pl17)* -1);
+    }
+
+    .EaLe\:PnBmVe18 {
+        bottom: calc(var(--Pl18)* -1);
+    }
+
+    .EaLe\:PnBmVe19 {
+        bottom: calc(var(--Pl19)* -1);
+    }
+
+    .EaLe\:PnBmVe20 {
+        bottom: calc(var(--Pl20)* -1);
+    }
+
+    .EaLe\:PnBmVe21 {
+        bottom: calc(var(--Pl21)* -1);
+    }
+
+    .EaLe\:PnBmVe22 {
+        bottom: calc(var(--Pl22)* -1);
+    }
+
+    .EaLe\:PnBmVe23 {
+        bottom: calc(var(--Pl23)* -1);
+    }
+
+    .EaLe\:PnBmVe24 {
+        bottom: calc(var(--Pl24)* -1);
+    }
+
+    .EaLe\:PnBmVe25 {
+        bottom: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position bottom Percentage**/
+    .EaLe\:PnBmVe1p {
+        bottom: -1%;
+    }
+
+    .EaLe\:PnBmVe2p {
+        bottom: -2%;
+    }
+
+    .EaLe\:PnBmVe3p {
+        bottom: -3%;
+    }
+
+    .EaLe\:PnBmVe4p {
+        bottom: -4%;
+    }
+
+    .EaLe\:PnBmVe5p {
+        bottom: -5%;
+    }
+
+    .EaLe\:PnBmVe6p {
+        bottom: -6%;
+    }
+
+    .EaLe\:PnBmVe7p {
+        bottom: -7%;
+    }
+
+    .EaLe\:PnBmVe8p {
+        bottom: -8%;
+    }
+
+    .EaLe\:PnBmVe9p {
+        bottom: -9%;
+    }
+
+    .EaLe\:PnBmVe10p {
+        bottom: -10%;
+    }
+
+    .EaLe\:PnBmVe11p {
+        bottom: -11%;
+    }
+
+    .EaLe\:PnBmVe12p {
+        bottom: -12%;
+    }
+
+    .EaLe\:PnBmVe13p {
+        bottom: -13%;
+    }
+
+    .EaLe\:PnBmVe14p {
+        bottom: -14%;
+    }
+
+    .EaLe\:PnBmVe15p {
+        bottom: -15%;
+    }
+
+    .EaLe\:PnBmVe16p {
+        bottom: -16%;
+    }
+
+    .EaLe\:PnBmVe17p {
+        bottom: -17%;
+    }
+
+    .EaLe\:PnBmVe18p {
+        bottom: -18%;
+    }
+
+    .EaLe\:PnBmVe19p {
+        bottom: -19%;
+    }
+
+    .EaLe\:PnBmVe20p {
+        bottom: -20%;
+    }
+
+    .EaLe\:PnBmVe21p {
+        bottom: -21%;
+    }
+
+    .EaLe\:PnBmVe22p {
+        bottom: -22%;
+    }
+
+    .EaLe\:PnBmVe23p {
+        bottom: -23%;
+    }
+
+    .EaLe\:PnBmVe24p {
+        bottom: -24%;
+    }
+
+    .EaLe\:PnBmVe25p {
+        bottom: -25%;
+    }
     /* Display */
     .EaLe\:DyBk {
         display: block
@@ -119316,7 +123364,813 @@ Extra Extra Large = EaEaLe = ≥1400px
     .EaEaLe\:PnTp100p {
         top: 100%;
     }
+    /**Negative Positions**/
+    .EaEaLe\:PnLtVe1 {
+        left: calc(var(--Pl1) * -1);
+    }
 
+    .EaEaLe\:PnLtVe2 {
+        left: calc(var(--Pl2) * -1);
+    }
+
+    .EaEaLe\:PnLtVe3 {
+        left: calc(var(--Pl3) * -1);
+    }
+
+    .EaEaLe\:PnLtVe4 {
+        left: calc(var(--Pl4) * -1);
+    }
+
+    .EaEaLe\:PnLtVe5 {
+        left: calc(var(--Pl5) * -1);
+    }
+
+    .EaEaLe\:PnLtVe6 {
+        left: calc(var(--Pl6) * -1);
+    }
+
+    .EaEaLe\:PnLtVe7 {
+        left: calc(var(--Pl7)* -1);
+    }
+
+    .EaEaLe\:PnLtVe8 {
+        left: calc(var(--Pl8)* -1);
+    }
+
+    .EaEaLe\:PnLtVe9 {
+        left: calc(var(--Pl9)* -1);
+    }
+
+    .EaEaLe\:PnLtVe10 {
+        left: calc(var(--Pl10)* -1);
+    }
+
+    .EaEaLe\:PnLtVe11 {
+        left: calc(var(--Pl11)* -1);
+    }
+
+    .EaEaLe\:PnLtVe12 {
+        left: calc(var(--Pl12)* -1);
+    }
+
+    .EaEaLe\:PnLtVe13 {
+        left: calc(var(--Pl13)* -1);
+    }
+
+    .EaEaLe\:PnLtVe14 {
+        left: calc(var(--Pl14)* -1);
+    }
+
+    .EaEaLe\:PnLtVe15 {
+        left: calc(var(--Pl15)* -1);
+    }
+
+    .EaEaLe\:PnLtVe16 {
+        left: calc(var(--Pl16)* -1);
+    }
+
+    .EaEaLe\:PnLtVe17 {
+        left: calc(var(--Pl17)* -1);
+    }
+
+    .EaEaLe\:PnLtVe18 {
+        left: calc(var(--Pl18)* -1);
+    }
+
+    .EaEaLe\:PnLtVe19 {
+        left: calc(var(--Pl19)* -1);
+    }
+
+    .EaEaLe\:PnLtVe20 {
+        left: calc(var(--Pl20)* -1);
+    }
+
+    .EaEaLe\:PnLtVe21 {
+        left: calc(var(--Pl21)* -1);
+    }
+
+    .EaEaLe\:PnLtVe22 {
+        left: calc(var(--Pl22)* -1);
+    }
+
+    .EaEaLe\:PnLtVe23 {
+        left: calc(var(--Pl23)* -1);
+    }
+
+    .EaEaLe\:PnLtVe24 {
+        left: calc(var(--Pl24)* -1);
+    }
+
+    .EaEaLe\:PnLtVe25 {
+        left: calc(var(--Pl25)* -1);
+    }
+
+    /**Position Left Percentage**/
+    .EaEaLe\:PnLtVe1p {
+        left: -1%;
+    }
+
+    .EaEaLe\:PnLtVe2p {
+        left: -2%;
+    }
+
+    .EaEaLe\:PnLtVe3p {
+        left: -3%;
+    }
+
+    .EaEaLe\:PnLtVe4p {
+        left: -4%;
+    }
+
+    .EaEaLe\:PnLtVe5p {
+        left: -5%;
+    }
+
+    .EaEaLe\:PnLtVe6p {
+        left: -6%;
+    }
+
+    .EaEaLe\:PnLtVe7p {
+        left: -7%;
+    }
+
+    .EaEaLe\:PnLtVe8p {
+        left: -8%;
+    }
+
+    .EaEaLe\:PnLtVe9p {
+        left: -9%;
+    }
+
+    .EaEaLe\:PnLtVe10p {
+        left: -10%;
+    }
+
+    .EaEaLe\:PnLtVe11p {
+        left: -11%;
+    }
+
+    .EaEaLe\:PnLtVe12p {
+        left: -12%;
+    }
+
+    .EaEaLe\:PnLtVe13p {
+        left: -13%;
+    }
+
+    .EaEaLe\:PnLtVe14p {
+        left: -14%;
+    }
+
+    .EaEaLe\:PnLtVe15p {
+        left: -15%;
+    }
+
+    .EaEaLe\:PnLtVe16p {
+        left: -16%;
+    }
+
+    .EaEaLe\:PnLtVe17p {
+        left: -17%;
+    }
+
+    .EaEaLe\:PnLtVe18p {
+        left: -18%;
+    }
+
+    .EaEaLe\:PnLtVe19p {
+        left: -19%;
+    }
+
+    .EaEaLe\:PnLtVe20p {
+        left: -20%;
+    }
+
+    .EaEaLe\:PnLtVe21p {
+        left: -21%;
+    }
+
+    .EaEaLe\:PnLtVe22p {
+        left: -22%;
+    }
+
+    .EaEaLe\:PnLtVe23p {
+        left: -23%;
+    }
+
+    .EaEaLe\:PnLtVe24p {
+        left: -24%;
+    }
+
+    .EaEaLe\:PnLtVe25p {
+        left: -25%;
+    }
+    /**Negative Position right**/
+    .EaEaLe\:PnRtVe1 {
+        right: calc(var(--Pl1) * -1);
+    }
+
+    .EaEaLe\:PnRtVe2 {
+        right: calc(var(--Pl2) * -1);
+    }
+
+    .EaEaLe\:PnRtVe3 {
+        right: calc(var(--Pl3) * -1);
+    }
+
+    .EaEaLe\:PnRtVe4 {
+        right: calc(var(--Pl4) * -1);
+    }
+
+    .EaEaLe\:PnRtVe5 {
+        right: calc(var(--Pl5) * -1);
+    }
+
+    .EaEaLe\:PnRtVe6 {
+        right: calc(var(--Pl6) * -1);
+    }
+
+    .EaEaLe\:PnRtVe7 {
+        right: calc(var(--Pl7)* -1);
+    }
+
+    .EaEaLe\:PnRtVe8 {
+        right: calc(var(--Pl8)* -1);
+    }
+
+    .EaEaLe\:PnRtVe9 {
+        right: calc(var(--Pl9)* -1);
+    }
+
+    .EaEaLe\:PnRtVe10 {
+        right: calc(var(--Pl10)* -1);
+    }
+
+    .EaEaLe\:PnRtVe11 {
+        right: calc(var(--Pl11)* -1);
+    }
+
+    .EaEaLe\:PnRtVe12 {
+        right: calc(var(--Pl12)* -1);
+    }
+
+    .EaEaLe\:PnRtVe13 {
+        right: calc(var(--Pl13)* -1);
+    }
+
+    .EaEaLe\:PnRtVe14 {
+        right: calc(var(--Pl14)* -1);
+    }
+
+    .EaEaLe\:PnRtVe15 {
+        right: calc(var(--Pl15)* -1);
+    }
+
+    .EaEaLe\:PnRtVe16 {
+        right: calc(var(--Pl16)* -1);
+    }
+
+    .EaEaLe\:PnRtVe17 {
+        right: calc(var(--Pl17)* -1);
+    }
+
+    .EaEaLe\:PnRtVe18 {
+        right: calc(var(--Pl18)* -1);
+    }
+
+    .EaEaLe\:PnRtVe19 {
+        right: calc(var(--Pl19)* -1);
+    }
+
+    .EaEaLe\:PnRtVe20 {
+        right: calc(var(--Pl20)* -1);
+    }
+
+    .EaEaLe\:PnRtVe21 {
+        right: calc(var(--Pl21)* -1);
+    }
+
+    .EaEaLe\:PnRtVe22 {
+        right: calc(var(--Pl22)* -1);
+    }
+
+    .EaEaLe\:PnRtVe23 {
+        right: calc(var(--Pl23)* -1);
+    }
+
+    .EaEaLe\:PnRtVe24 {
+        right: calc(var(--Pl24)* -1);
+    }
+
+    .EaEaLe\:PnRtVe25 {
+        right: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position right Percentage**/
+    .EaEaLe\:PnRtVe1p {
+        right: -1%;
+    }
+
+    .EaEaLe\:PnRtVe2p {
+        right: -2%;
+    }
+
+    .EaEaLe\:PnRtVe3p {
+        right: -3%;
+    }
+
+    .EaEaLe\:PnRtVe4p {
+        right: -4%;
+    }
+
+    .EaEaLe\:PnRtVe5p {
+        right: -5%;
+    }
+
+    .EaEaLe\:PnRtVe6p {
+        right: -6%;
+    }
+
+    .EaEaLe\:PnRtVe7p {
+        right: -7%;
+    }
+
+    .EaEaLe\:PnRtVe8p {
+        right: -8%;
+    }
+
+    .EaEaLe\:PnRtVe9p {
+        right: -9%;
+    }
+
+    .EaEaLe\:PnRtVe10p {
+        right: -10%;
+    }
+
+    .EaEaLe\:PnRtVe11p {
+        right: -11%;
+    }
+
+    .EaEaLe\:PnRtVe12p {
+        right: -12%;
+    }
+
+    .EaEaLe\:PnRtVe13p {
+        right: -13%;
+    }
+
+    .EaEaLe\:PnRtVe14p {
+        right: -14%;
+    }
+
+    .EaEaLe\:PnRtVe15p {
+        right: -15%;
+    }
+
+    .EaEaLe\:PnRtVe16p {
+        right: -16%;
+    }
+
+    .EaEaLe\:PnRtVe17p {
+        right: -17%;
+    }
+
+    .EaEaLe\:PnRtVe18p {
+        right: -18%;
+    }
+
+    .EaEaLe\:PnRtVe19p {
+        right: -19%;
+    }
+
+    .EaEaLe\:PnRtVe20p {
+        right: -20%;
+    }
+
+    .EaEaLe\:PnRtVe21p {
+        right: -21%;
+    }
+
+    .EaEaLe\:PnRtVe22p {
+        right: -22%;
+    }
+
+    .EaEaLe\:PnRtVe23p {
+        right: -23%;
+    }
+
+    .EaEaLe\:PnRtVe24p {
+        right: -24%;
+    }
+
+    .EaEaLe\:PnRtVe25p {
+        right: -25%;
+    }
+
+    /**Negative Position top**/
+    .EaEaLe\:PnTpVe1 {
+        top: calc(var(--Pl1) * -1);
+    }
+
+    .EaEaLe\:PnTpVe2 {
+        top: calc(var(--Pl2) * -1);
+    }
+
+    .EaEaLe\:PnTpVe3 {
+        top: calc(var(--Pl3) * -1);
+    }
+
+    .EaEaLe\:PnTpVe4 {
+        top: calc(var(--Pl4) * -1);
+    }
+
+    .EaEaLe\:PnTpVe5 {
+        top: calc(var(--Pl5) * -1);
+    }
+
+    .EaEaLe\:PnTpVe6 {
+        top: calc(var(--Pl6) * -1);
+    }
+
+    .EaEaLe\:PnTpVe7 {
+        top: calc(var(--Pl7)* -1);
+    }
+
+    .EaEaLe\:PnTpVe8 {
+        top: calc(var(--Pl8)* -1);
+    }
+
+    .EaEaLe\:PnTpVe9 {
+        top: calc(var(--Pl9)* -1);
+    }
+
+    .EaEaLe\:PnTpVe10 {
+        top: calc(var(--Pl10)* -1);
+    }
+
+    .EaEaLe\:PnTpVe11 {
+        top: calc(var(--Pl11)* -1);
+    }
+
+    .EaEaLe\:PnTpVe12 {
+        top: calc(var(--Pl12)* -1);
+    }
+
+    .EaEaLe\:PnTpVe13 {
+        top: calc(var(--Pl13)* -1);
+    }
+
+    .EaEaLe\:PnTpVe14 {
+        top: calc(var(--Pl14)* -1);
+    }
+
+    .EaEaLe\:PnTpVe15 {
+        top: calc(var(--Pl15)* -1);
+    }
+
+    .EaEaLe\:PnTpVe16 {
+        top: calc(var(--Pl16)* -1);
+    }
+
+    .EaEaLe\:PnTpVe17 {
+        top: calc(var(--Pl17)* -1);
+    }
+
+    .EaEaLe\:PnTpVe18 {
+        top: calc(var(--Pl18)* -1);
+    }
+
+    .EaEaLe\:PnTpVe19 {
+        top: calc(var(--Pl19)* -1);
+    }
+
+    .EaEaLe\:PnTpVe20 {
+        top: calc(var(--Pl20)* -1);
+    }
+
+    .EaEaLe\:PnTpVe21 {
+        top: calc(var(--Pl21)* -1);
+    }
+
+    .EaEaLe\:PnTpVe22 {
+        top: calc(var(--Pl22)* -1);
+    }
+
+    .EaEaLe\:PnTpVe23 {
+        top: calc(var(--Pl23)* -1);
+    }
+
+    .EaEaLe\:PnTpVe24 {
+        top: calc(var(--Pl24)* -1);
+    }
+
+    .EaEaLe\:PnTpVe25 {
+        top: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position top Percentage**/
+    .EaEaLe\:PnTpVe1p {
+        top: -1%;
+    }
+
+    .EaEaLe\:PnTpVe2p {
+        top: -2%;
+    }
+
+    .EaEaLe\:PnTpVe3p {
+        top: -3%;
+    }
+
+    .EaEaLe\:PnTpVe4p {
+        top: -4%;
+    }
+
+    .EaEaLe\:PnTpVe5p {
+        top: -5%;
+    }
+
+    .EaEaLe\:PnTpVe6p {
+        top: -6%;
+    }
+
+    .EaEaLe\:PnTpVe7p {
+        top: -7%;
+    }
+
+    .EaEaLe\:PnTpVe8p {
+        top: -8%;
+    }
+
+    .EaEaLe\:PnTpVe9p {
+        top: -9%;
+    }
+
+    .EaEaLe\:PnTpVe10p {
+        top: -10%;
+    }
+
+    .EaEaLe\:PnTpVe11p {
+        top: -11%;
+    }
+
+    .EaEaLe\:PnTpVe12p {
+        top: -12%;
+    }
+
+    .EaEaLe\:PnTpVe13p {
+        top: -13%;
+    }
+
+    .EaEaLe\:PnTpVe14p {
+        top: -14%;
+    }
+
+    .EaEaLe\:PnTpVe15p {
+        top: -15%;
+    }
+
+    .EaEaLe\:PnTpVe16p {
+        top: -16%;
+    }
+
+    .EaEaLe\:PnTpVe17p {
+        top: -17%;
+    }
+
+    .EaEaLe\:PnTpVe18p {
+        top: -18%;
+    }
+
+    .EaEaLe\:PnTpVe19p {
+        top: -19%;
+    }
+
+    .EaEaLe\:PnTpVe20p {
+        top: -20%;
+    }
+
+    .EaEaLe\:PnTpVe21p {
+        top: -21%;
+    }
+
+    .EaEaLe\:PnTpVe22p {
+        top: -22%;
+    }
+
+    .EaEaLe\:PnTpVe23p {
+        top: -23%;
+    }
+
+    .EaEaLe\:PnTpVe24p {
+        top: -24%;
+    }
+
+    .EaEaLe\:PnTpVe25p {
+        top: -25%;
+    }
+
+
+    /**Negative Position bottom**/
+    .EaEaLe\:PnBmVe1 {
+        bottom: calc(var(--Pl1) * -1);
+    }
+
+    .EaEaLe\:PnBmVe2 {
+        bottom: calc(var(--Pl2) * -1);
+    }
+
+    .EaEaLe\:PnBmVe3 {
+        bottom: calc(var(--Pl3) * -1);
+    }
+
+    .EaEaLe\:PnBmVe4 {
+        bottom: calc(var(--Pl4) * -1);
+    }
+
+    .EaEaLe\:PnBmVe5 {
+        bottom: calc(var(--Pl5) * -1);
+    }
+
+    .EaEaLe\:PnBmVe6 {
+        bottom: calc(var(--Pl6) * -1);
+    }
+
+    .EaEaLe\:PnBmVe7 {
+        bottom: calc(var(--Pl7)* -1);
+    }
+
+    .EaEaLe\:PnBmVe8 {
+        bottom: calc(var(--Pl8)* -1);
+    }
+
+    .EaEaLe\:PnBmVe9 {
+        bottom: calc(var(--Pl9)* -1);
+    }
+
+    .EaEaLe\:PnBmVe10 {
+        bottom: calc(var(--Pl10)* -1);
+    }
+
+    .EaEaLe\:PnBmVe11 {
+        bottom: calc(var(--Pl11)* -1);
+    }
+
+    .EaEaLe\:PnBmVe12 {
+        bottom: calc(var(--Pl12)* -1);
+    }
+
+    .EaEaLe\:PnBmVe13 {
+        bottom: calc(var(--Pl13)* -1);
+    }
+
+    .EaEaLe\:PnBmVe14 {
+        bottom: calc(var(--Pl14)* -1);
+    }
+
+    .EaEaLe\:PnBmVe15 {
+        bottom: calc(var(--Pl15)* -1);
+    }
+
+    .EaEaLe\:PnBmVe16 {
+        bottom: calc(var(--Pl16)* -1);
+    }
+
+    .EaEaLe\:PnBmVe17 {
+        bottom: calc(var(--Pl17)* -1);
+    }
+
+    .EaEaLe\:PnBmVe18 {
+        bottom: calc(var(--Pl18)* -1);
+    }
+
+    .EaEaLe\:PnBmVe19 {
+        bottom: calc(var(--Pl19)* -1);
+    }
+
+    .EaEaLe\:PnBmVe20 {
+        bottom: calc(var(--Pl20)* -1);
+    }
+
+    .EaEaLe\:PnBmVe21 {
+        bottom: calc(var(--Pl21)* -1);
+    }
+
+    .EaEaLe\:PnBmVe22 {
+        bottom: calc(var(--Pl22)* -1);
+    }
+
+    .EaEaLe\:PnBmVe23 {
+        bottom: calc(var(--Pl23)* -1);
+    }
+
+    .EaEaLe\:PnBmVe24 {
+        bottom: calc(var(--Pl24)* -1);
+    }
+
+    .EaEaLe\:PnBmVe25 {
+        bottom: calc(var(--Pl25)* -1);
+    }
+
+    /**Neagative Position bottom Percentage**/
+    .EaEaLe\:PnBmVe1p {
+        bottom: -1%;
+    }
+
+    .EaEaLe\:PnBmVe2p {
+        bottom: -2%;
+    }
+
+    .EaEaLe\:PnBmVe3p {
+        bottom: -3%;
+    }
+
+    .EaEaLe\:PnBmVe4p {
+        bottom: -4%;
+    }
+
+    .EaEaLe\:PnBmVe5p {
+        bottom: -5%;
+    }
+
+    .EaEaLe\:PnBmVe6p {
+        bottom: -6%;
+    }
+
+    .EaEaLe\:PnBmVe7p {
+        bottom: -7%;
+    }
+
+    .EaEaLe\:PnBmVe8p {
+        bottom: -8%;
+    }
+
+    .EaEaLe\:PnBmVe9p {
+        bottom: -9%;
+    }
+
+    .EaEaLe\:PnBmVe10p {
+        bottom: -10%;
+    }
+
+    .EaEaLe\:PnBmVe11p {
+        bottom: -11%;
+    }
+
+    .EaEaLe\:PnBmVe12p {
+        bottom: -12%;
+    }
+
+    .EaEaLe\:PnBmVe13p {
+        bottom: -13%;
+    }
+
+    .EaEaLe\:PnBmVe14p {
+        bottom: -14%;
+    }
+
+    .EaEaLe\:PnBmVe15p {
+        bottom: -15%;
+    }
+
+    .EaEaLe\:PnBmVe16p {
+        bottom: -16%;
+    }
+
+    .EaEaLe\:PnBmVe17p {
+        bottom: -17%;
+    }
+
+    .EaEaLe\:PnBmVe18p {
+        bottom: -18%;
+    }
+
+    .EaEaLe\:PnBmVe19p {
+        bottom: -19%;
+    }
+
+    .EaEaLe\:PnBmVe20p {
+        bottom: -20%;
+    }
+
+    .EaEaLe\:PnBmVe21p {
+        bottom: -21%;
+    }
+
+    .EaEaLe\:PnBmVe22p {
+        bottom: -22%;
+    }
+
+    .EaEaLe\:PnBmVe23p {
+        bottom: -23%;
+    }
+
+    .EaEaLe\:PnBmVe24p {
+        bottom: -24%;
+    }
+
+    .EaEaLe\:PnBmVe25p {
+        bottom: -25%;
+    }
     /* Display */
     .EaEaLe\:DyBk {
         display: block


### PR DESCRIPTION
Added new CSS utility classes (PnLtVe1–25, PnRtVe1–25, PnTpVe1–25, PnBtVe1–25) to CelebrateStyle.css for applying negative positional offsets in px. This update enables quick, consistent negative positioning for left, right, top, and bottom, improving layout flexibility and developer productivity. Documented usage in the style guide.