### PR TITLE
Fix: Extra div removed from the slider.cshtml

### DIFF
--- a/Views/UI/Slider.cshtml
+++ b/Views/UI/Slider.cshtml
@@ -1497,7 +1497,6 @@ document.addEventListener('DOMContentLoaded', function () {
                     &lt;/div&gt;
 
                 &lt;/div&gt;
-            &lt;/div&gt;
             </code>
             <code class="language-js" style="background: none">
                 const stackedSliderObj = {


### PR DESCRIPTION
## Bug Description
An extra <div> was present inside the stacked slider markup in `Views/UI/Slider.cshtml`.  
This caused incorrect HTML structure and potential layout/spacing issues.

## Fix Implemented
- Removed the unnecessary <div> element inside the stacked slider section.
- Verified that the remaining structure is valid and renders correctly.
- Confirmed no layout or styling regressions after removal.

## Expected Behavior
- HTML structure is now clean and correct.
- Stacked slider renders without extra unwanted wrappers.

## Steps to Test
1. Open `Views/UI/Slider.cshtml`.
2. Check the stacked slider section.
3. Confirm that there is no extra <div> present.
4. Verify UI renders correctly without spacing/layout issues.

## Related Issue
Closes #35